### PR TITLE
stop command: add force option

### DIFF
--- a/vm_manager/helpers/libvirt.py
+++ b/vm_manager/helpers/libvirt.py
@@ -91,6 +91,13 @@ class LibVirtManager:
         """
         self._conn.lookupByName(vm_name).shutdown()
 
+    def force_stop(self, vm_name):
+        """
+        Forces a VM to stop
+        :param vm_name: the VM to be stopped
+        """
+        self._conn.lookupByName(vm_name).destroy()
+
     def status(self, vm_name):
         """
         Get the VM status

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -417,7 +417,7 @@ def status(vm_name):
             return "Disabled"
 
 
-def stop(vm_name):
+def stop(vm_name, force=False):
     """
     Stop a VM
     :param vm_name: the VM to be stopped
@@ -428,6 +428,10 @@ def stop(vm_name):
             state = p.show()
             if state != "Stopped":
                 logger.info("Stop " + vm_name)
+                if force:
+                    logger.info(
+                        "The option --force isn't implemented yet for cluster mode"
+                    )
                 p.stop()
                 p.wait_for("Stopped")
                 logger.info("VM " + vm_name + " stopped")

--- a/vm_manager/vm_manager_libvirt.py
+++ b/vm_manager/vm_manager_libvirt.py
@@ -60,7 +60,7 @@ def remove(vm_name):
         if vm_name not in lvm.list():
             logger.info(vm_name + "does not exist")
         elif lvm._conn.lookupByName(vm_name).isActive():
-            lvm.stop(vm_name)
+            lvm.force_stop(vm_name)
         lvm.undefine(vm_name)
 
     logger.info("VM " + vm_name + " removed")
@@ -78,15 +78,19 @@ def start(vm_name):
     logger.info("VM " + vm_name + " started")
 
 
-def stop(vm_name):
+def stop(vm_name, force=False):
     """
     Stop a VM
     :param vm_name: the VM to be stopped
+    :param force: Set to True to force stop (virtually unplug the VM)
     """
     with LibVirtManager() as lvm:
-        lvm.stop(vm_name)
-
-    logger.info("VM " + vm_name + " stopped")
+        if force:
+            lvm.force_stop(vm_name)
+            logger.info("Forced VM " + vm_name + " stop")
+        else:
+            lvm.stop(vm_name)
+            logger.info("VM " + vm_name + " stopped")
 
 
 def status(vm_name):

--- a/vm_manager_cmd.py
+++ b/vm_manager_cmd.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     create_parser = subparsers.add_parser("create", help="Create a new VM")
     subparsers.add_parser("remove", help="Remove a VM")
     subparsers.add_parser("start", help="Start a VM")
-    subparsers.add_parser("stop", help="Stop a VM")
+    stop_parser = subparsers.add_parser("stop", help="Stop a VM")
     subparsers.add_parser("list", help="List all VMs")
     subparsers.add_parser("status", help="Print VM status")
 
@@ -92,6 +92,13 @@ if __name__ == "__main__":
             )
     create_parser.add_argument(
         "--xml", type=str, required=True, help="VM libvirt XML path"
+    )
+    stop_parser.add_argument(
+        "-f",
+        "--force",
+        required=False,
+        action="store_true",
+        help="Force VM stop (virtual unplug) - not implemented yet for cluster mode",
     )
 
     if vm_manager.cluster_mode:
@@ -240,9 +247,9 @@ if __name__ == "__main__":
     elif args.command == "start":
         vm_manager.start(args.name)
     elif args.command == "stop":
-        vm_manager.stop(args.name)
+        vm_manager.stop(args.name, force=args.force)
     elif args.command == "remove":
-        vm_manager.remove(args.name)
+        vm_manager.remove(args.name, force=args.force)
     elif args.command == "create":
         with open(args.xml, "r") as xml:
             xml_data = xml.read()


### PR DESCRIPTION
The force option was not implemented yet for stopping a VM.
It can be called on the command line with -f or --force.
If vm_manager is used in non-cluster mode, the command "stop --force" will call libvirt function destroy() instead of shutdown().
The option remains unimplemented for cluster mode : it will still call Pacemaker.stop()