### PR TITLE
bug: Stopped guest (because failure) can't be administratevely Stopped

### DIFF
--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -157,7 +157,7 @@ class Pacemaker:
                     resource, _, status = line.split("\t")
                     resource = resource.strip(" ")
                     if resource == self._resource:
-                        return status.lstrip().split(" ")[0]
+                        return status.lstrip()
                 except ValueError:
                     pass
 

--- a/vm_manager/helpers/tests/pacemaker/stop_vm.py
+++ b/vm_manager/helpers/tests/pacemaker/stop_vm.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         if state == "Started":
             print("Stop " + VM_NAME)
             p.stop()
-            p.wait_for("Stopped")
+            p.wait_for("Stopped (disabled)")
             print("VM " + VM_NAME + " stopped")
 
         else:

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -372,7 +372,7 @@ def disable_vm(vm_name):
     with Pacemaker(vm_name) as p:
 
         if vm_name in p.list_resources():
-            if p.show() != "Stopped":
+            if p.show().split(" ")[0] != "Stopped":
                 logger.info("VM " + vm_name + " is running, force delete")
                 p.delete(True)
             else:
@@ -448,14 +448,14 @@ def stop(vm_name, force=False):
 
         if vm_name in p.list_resources():
             state = p.show()
-            if state != "Stopped":
+            if state != "Stopped (disabled)":
                 logger.info("Stop " + vm_name)
                 if force:
                     logger.info(
                         "The option --force isn't implemented yet for cluster mode"
                     )
                 p.stop()
-                p.wait_for("Stopped")
+                p.wait_for("Stopped (disabled)")
                 logger.info("VM " + vm_name + " stopped")
             else:
                 logger.info("VM " + vm_name + " is already stopped")


### PR DESCRIPTION
If a guest is stopped because of a failure to start, the vm_manager stop command won't work, because the status of the guest if already "Stopped".
This commit makes vm_manager consider differently "Stopped" (because of failure to start) and "Stopped (disabled)" (administratively Stopped).