### PR TITLE
pacemaker/start_vm.py: consider "disabled" option

### DIFF
--- a/vm_manager/helpers/tests/pacemaker/start_vm.py
+++ b/vm_manager/helpers/tests/pacemaker/start_vm.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
 
         state = p.show()
         print(VM_NAME + " state: " + state)
-        if state == "Stopped":
+        if state == "Stopped (disabled)":
             print("Start " + VM_NAME)
             p.start()
             p.wait_for("Started")


### PR DESCRIPTION
A vm that is stopped by a command is not in state "stopped", but in the state "stopped (disabled)".
This commit correct the script start_vm.py that is played after stop_vm.py. The vm is thus stopped manually.