### PR TITLE
add live migration timeout option

### DIFF
--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -178,7 +178,7 @@ class Pacemaker:
         stop_timeout=15,
         monitor_timeout=60,
         monitor_interval=10,
-        migrate_from_timeout=60,
+        migrate_from_timeout=120,
         migrate_to_timeout=120,
         is_managed=True,
         force_stop=False,

--- a/vm_manager_cmd.py
+++ b/vm_manager_cmd.py
@@ -162,6 +162,13 @@ if __name__ == "__main__":
                 default=None,
                 help="Sets the user used for live migration",
             )
+            p.add_argument(
+                "--migration-from-timeout",
+                type=str,
+                required=False,
+                default=None,
+                help="Sets the timeout in seconds for live migration (default 120)",
+            )
 
         clone_parser.add_argument(
             "--dst_name", type=str, required=True, help="Destination VM name"
@@ -278,6 +285,7 @@ if __name__ == "__main__":
                 pinned_host=args.pinned_host,
                 live_migration=args.enable_live_migration,
                 migration_user=args.migration_user,
+                migration_from_timeout=args.migration_from_timeout,
             )
         else:
             vm_manager.create(args.name, xml_data)
@@ -297,6 +305,7 @@ if __name__ == "__main__":
             pinned_host=args.pinned_host,
             live_migration=args.enable_live_migration,
             migration_user=args.migration_user,
+            migration_from_timeout=args.migration_from_timeout,
             clear_constraint=args.clear_constraint,
         )
     elif args.command == "disable":


### PR DESCRIPTION
This commit allows a user to change the default delay allowed for live migration (120s). Increasing this delay might allow live migration for Guest with a lot of memory, for which 120s may be to short to migrate.