### PR TITLE
increase stop timeout to 25s

### DIFF
--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -175,7 +175,7 @@ class Pacemaker:
         self,
         xml,
         start_timeout=120,
-        stop_timeout=15,
+        stop_timeout=25,
         monitor_timeout=60,
         monitor_interval=10,
         migrate_from_timeout=60,


### PR DESCRIPTION
Since we must give 12s to pacemaker to forcefully destroy a guest, this leaves 3 seconds to gracefully terminate it. This is not enough. This commit increase the shutdown timeout to 25s, giving libvirt:
- 13 seconds to gracefully shutdown the guest
- 12 seconds to forcefully destroy it