### PR TITLE
vm_manager/helpers/pacemaker: avoid to be blocked in crm configure

### DIFF
--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -329,6 +329,10 @@ class Pacemaker:
         """
         Run a crm configure command
         """
+        # Do not run empty command otherwise crm enter in crm configure
+        # interactive mode and block the execution
+        if not cmd:
+            return
         args = [
             "crm",
             "configure",

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -142,7 +142,7 @@ def _configure_vm(
             )
         if crm_config_cmd:
             crm_config_cmd_multiline = """{}""".format("\n".join(crm_config_cmd))
-            rbd.set_image_metadata(disk_name, "_crm_config_cmd", crm_config_cmd_multiline)    
+            rbd.set_image_metadata(disk_name, "_crm_config_cmd", crm_config_cmd_multiline)
         if metadata:
             for name, data in metadata.items():
                 rbd.set_image_metadata(disk_name, name, data)


### PR DESCRIPTION
If the crm configure is a empty string, crm configure enter in interactive mode and block the execution.