### PR TITLE
bug in crm_config_cmd

### DIFF
--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -138,8 +138,8 @@ def _configure_vm( vm_options ):
             rbd.set_image_metadata(disk_name, "_pinned_host", vm_options["pinned_host"])
         elif "preferred_host" in vm_options:
             rbd.set_image_metadata(disk_name, "_preferred_host", vm_options["preferred_host"])
-        if "add_crm_config_cmd" in vm_options:
-            vm_options["crm_config_cmd_multiline"] = """{}""".format("\n".join(vm_options["add_crm_config_cmd"]))
+        if "crm_config_cmd" in vm_options:
+            vm_options["crm_config_cmd_multiline"] = """{}""".format("\n".join(vm_options["crm_config_cmd"]))
             rbd.set_image_metadata(disk_name, "_crm_config_cmd", vm_options["crm_config_cmd_multiline"])
         if "priority" in vm_options:
             rbd.set_image_metadata(disk_name, "_priority", vm_options["priority"])

--- a/vm_manager_cmd.py
+++ b/vm_manager_cmd.py
@@ -296,6 +296,7 @@ if __name__ == "__main__":
         with open(args.xml, "r") as xml:
             args.base_xml = xml.read()
         args.live_migration = args.enable_live_migration
+        args.crm_config_cmd = args.add_crm_config_cmd
         vm_manager.create(vars(args))
     elif args.command == "clone":
         args.base_xml = None
@@ -303,6 +304,7 @@ if __name__ == "__main__":
             with open(args.xml, "r") as xml:
                 args.base_xml = xml.read()
         args.live_migration = args.enable_live_migration
+        args.crm_config_cmd = args.add_crm_config_cmd
         vm_manager.clone(vars(args))
     elif args.command == "disable":
         vm_manager.disable_vm(args.name)


### PR DESCRIPTION
the name of the "vm_options" used for crm_config_cmd was not coherent:
- the vm-mgr cli uses "add_crm_config_cmd"
- the vm-manager livrary code uses "add_crm_config_cmd"
- the ansible module uses "crm_config_cmd"

That makes this option work on the cli, but not with the ansible module.

This commit makes it coherent to that everybody uses "crm_config_cmd":
- in the vm-mgr cli we copy "add_crm_config_cmd" to "crm_config_cmd"
- in the vm-manager library code we use "crm_config_cmd" instead of "add_crm_config_cmd"