### PR TITLE
vm_manager: add Pacemaker remote node support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="mathieu.dupre@savoirfairelinux.com",
     description="Managed VMs in Seapath cluster",
     include_package_data=True,
-    install_requires=["flask","Flask-WTF"],
+    install_requires=["flask", "Flask-WTF"],
     scripts=[
         "vm_manager/helpers/libvirt_cmd.py",
         "vm_manager/helpers/tests/pacemaker/add_vm.py",

--- a/vm_manager/__init__.py
+++ b/vm_manager/__init__.py
@@ -30,6 +30,8 @@ if cluster_mode:
         get_metadata,
         set_metadata,
         add_colocation,
+        remove_pacemaker_remote,
+        add_pacemaker_remote,
     )
 else:
     from .vm_manager_libvirt import (

--- a/vm_manager/helpers/libvirt_cmd.py
+++ b/vm_manager/helpers/libvirt_cmd.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
                 print(vm)
     elif args.command == "secrets":
         with LibVirtManager() as libvirt_manager:
-            for (name, value) in libvirt_manager.get_virsh_secrets().items():
+            for name, value in libvirt_manager.get_virsh_secrets().items():
                 print("{}: {}".format(name, value))
     elif args.command == "define":
         with open(args.xml, "r") as f:

--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -183,10 +183,7 @@ class Pacemaker:
             check=True,
         )
 
-    def add_vm(
-        self,
-        vm_options,
-    ):
+    def add_vm(self, vm_options):
         """
         Add VM to Pacemaker cluster.
         """
@@ -197,33 +194,33 @@ class Pacemaker:
             self._resource,
             "ocf:seapath:VirtualDomain",
             "params",
-            "force_stop=" + (str(vm_options["force_stop"]).lower() if "force_stop" in vm_options else "false"),
-            "migration_downtime=" + (str(vm_options["migration_downtime"]) if "migration_downtime" in vm_options else "0"),
+            "force_stop=" + str(vm_options.get("force_stop", False)).lower(),
+            "migration_downtime=" + str(vm_options.get("migration_downtime", 0)),
             "config=" + vm_options["xml"],
             "hypervisor='qemu:///system'",
-            "seapath='{}'".format(str(vm_options["seapath_managed"]).lower() if "seapath_managed" in vm_options else "false"),
+            "seapath='{}'".format(str(vm_options.get("seapath_managed", False)).lower()),
             "migration_transport=ssh",
-            "migration_user='" + ( vm_options["migration_user"] if "migration_user" in vm_options else "root") + "'",
+            "migration_user='" + vm_options.get("migration_user", "root") + "'",
             "meta",
-            "allow-migrate='" + ( str(vm_options["live_migration"]).lower() if "live_migration" in vm_options else "false") + "'",
-            "is-managed=" + ( str(vm_options["is_managed"]).lower() if "is_managed" in vm_options else "true" ),
-            "priority='" + ( vm_options["priority"] if "priority" in vm_options else "0" ) + "'",
+            "allow-migrate='" + str(vm_options.get("live_migration", False)).lower() + "'",
+            "is-managed=" + str(vm_options.get("is_managed", True)).lower(),
+            "priority='" + vm_options.get("priority", "0") + "'",
             "op",
             "start",
-            "timeout='" + ( vm_options["start_timeout"] if "start_timeout" in vm_options else "120") + "'",
+            "timeout='" + vm_options.get("start_timeout", "120") + "'",
             "op",
             "stop",
-            "timeout='" + ( vm_options["stop_timeout"] if "stop_timeout" in vm_options else "30" )+ "'",
+            "timeout='" + vm_options.get("stop_timeout", "30") + "'",
             "op",
             "migrate_from",
-            "timeout='" + ( vm_options["migrate_from_timeout"] if "migrate_from_timeout" in vm_options else "60" ) + "'",
+            "timeout='" + vm_options.get("migrate_from_timeout", "60") + "'",
             "op",
             "migrate_to",
-            "timeout='" + ( vm_options["migrate_to_timeout"] if "migrate_to_timeout" in vm_options else "120" ) + "'",
+            "timeout='" + vm_options.get("migrate_to_timeout", "120") + "'",
             "op",
             "monitor",
-            "timeout='" + ( vm_options["monitor_timeout"] if "monitor_timeout" in vm_options else "60" ) + "'",
-            "interval='" + ( vm_options["monitor_interval"] if "monitor_interval" in vm_options else "10" ) + "'",
+            "timeout='" + vm_options.get("monitor_timeout", "60") + "'",
+            "interval='" + vm_options.get("monitor_interval", "10") + "'",
         ]
 
         logger.info("Execute: " + (str(subprocess.list2cmdline(args))))

--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -222,6 +223,25 @@ class Pacemaker:
             "timeout='" + vm_options.get("monitor_timeout", "60") + "'",
             "interval='" + vm_options.get("monitor_interval", "10") + "'",
         ]
+        if vm_options.get("pacemaker_remote"):
+            args += [
+                "meta",
+                "remote-node='" + vm_options["pacemaker_remote"] + "'",
+            ]
+            if vm_options.get("pacemaker_remote_addr"):
+                args += [
+                    "remote-addr='" + vm_options["pacemaker_remote_addr"] + "'"
+                ]
+            if vm_options.get("pacemaker_remote_port"):
+                args += [
+                    "remote-port='" + vm_options["pacemaker_remote_port"] + "'"
+                ]
+            if vm_options.get("pacemaker_remote_timeout"):
+                args += [
+                    "remote-connect-timeout='"
+                    + vm_options["pacemaker_remote_timeout"]
+                    + "'"
+                ]
 
         logger.info("Execute: " + (str(subprocess.list2cmdline(args))))
         subprocess.run(args, check=True)
@@ -328,6 +348,39 @@ class Pacemaker:
             "configure",
         ]
         args.extend(cmd.split(" "))
+
+        subprocess.run(args, check=True)
+
+    def add_meta(self, key, value):
+        """
+        Add a meta to the resource
+        :param meta: the meta to add
+        """
+        args = [
+            "crm",
+            "resource",
+            "meta",
+            self._resource,
+            "set",
+            key,
+            value
+        ]
+
+        subprocess.run(args, check=True)
+
+    def remove_meta(self, key):
+        """
+        Remove a meta from the resource
+        :param meta: the meta to remove
+        """
+        args = [
+            "crm",
+            "resource",
+            "meta",
+            self._resource,
+            "delete",
+            key,
+        ]
 
         subprocess.run(args, check=True)
 

--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -120,8 +120,10 @@ class Pacemaker:
             return resources
 
         for line in output.split("\n"):
-            if re.match(r".*ocf::?seapath:VirtualDomain.*",line):
-                resources += [line.split("\t")[0].replace("*","").replace(" ","")]
+            if re.match(r".*ocf::?seapath:VirtualDomain.*", line):
+                resources += [
+                    line.split("\t")[0].replace("*", "").replace(" ", "")
+                ]
         return resources
 
     def delete(self, force=False, clean=False):
@@ -130,13 +132,11 @@ class Pacemaker:
         resources.
         """
         if clean:
-            args = (
-                [
-                    "crm",
-                    "resource",
-                    "clean",
-                ]
-            )
+            args = [
+                "crm",
+                "resource",
+                "clean",
+            ]
             logger.info("Execute: " + (str(subprocess.list2cmdline(args))))
             subprocess.run(args, check=True)
 
@@ -165,10 +165,10 @@ class Pacemaker:
         output_list = output.stdout.decode("utf-8").split("\n")
 
         for line in output_list:
-            if re.match(r".*ocf::?seapath:VirtualDomain.*",line):
+            if re.match(r".*ocf::?seapath:VirtualDomain.*", line):
                 try:
                     resource, _, status = line.split("\t")
-                    resource = resource.replace("*","").replace(" ","")
+                    resource = resource.replace("*", "").replace(" ", "")
                     if resource == self._resource:
                         return status.lstrip()
                 except ValueError:
@@ -196,14 +196,21 @@ class Pacemaker:
             "ocf:seapath:VirtualDomain",
             "params",
             "force_stop=" + str(vm_options.get("force_stop", False)).lower(),
-            "migration_downtime=" + str(vm_options.get("migration_downtime", 0)),
+            "migration_downtime="
+            + str(vm_options.get("migration_downtime", 0)),
             "config=" + vm_options["xml"],
             "hypervisor='qemu:///system'",
-            "seapath='{}'".format(str(vm_options.get("seapath_managed", False)).lower()),
+            "seapath='{}'".format(
+                str(vm_options.get("seapath_managed", False)).lower()
+            ),
             "migration_transport=ssh",
-            "migration_user='" + vm_options.get("migration_user", "root") + "'",
+            "migration_user='"
+            + vm_options.get("migration_user", "root")
+            + "'",
             "meta",
-            "allow-migrate='" + str(vm_options.get("live_migration", False)).lower() + "'",
+            "allow-migrate='"
+            + str(vm_options.get("live_migration", False)).lower()
+            + "'",
             "is-managed=" + str(vm_options.get("is_managed", True)).lower(),
             "priority='" + vm_options.get("priority", "0") + "'",
             "op",
@@ -356,15 +363,7 @@ class Pacemaker:
         Add a meta to the resource
         :param meta: the meta to add
         """
-        args = [
-            "crm",
-            "resource",
-            "meta",
-            self._resource,
-            "set",
-            key,
-            value
-        ]
+        args = ["crm", "resource", "meta", self._resource, "set", key, value]
 
         subprocess.run(args, check=True)
 

--- a/vm_manager/helpers/rbd_manager.py
+++ b/vm_manager/helpers/rbd_manager.py
@@ -144,7 +144,7 @@ class RbdManager:
         if not isinstance(size, int):
             unit_list = ["B", "K", "M", "G", "T"]
             i = unit_list.index(size[-1])
-            size = int(size[:-1]) * 1024 ** i
+            size = int(size[:-1]) * 1024**i
 
         if self.image_exists(img):
             if overwrite:

--- a/vm_manager/vm_manager_api.py
+++ b/vm_manager/vm_manager_api.py
@@ -1,11 +1,10 @@
 from flask import Flask
 from flask_wtf.csrf import CSRFProtect
+import vm_manager as v
 
 app = Flask(__name__)
 csrf = CSRFProtect()
 csrf.init_app(app)
-
-import vm_manager as v
 
 
 def execfunc(func, guest):

--- a/vm_manager/vm_manager_api.py
+++ b/vm_manager/vm_manager_api.py
@@ -1,37 +1,44 @@
 from flask import Flask
 from flask_wtf.csrf import CSRFProtect
+
 app = Flask(__name__)
 csrf = CSRFProtect()
 csrf.init_app(app)
 
 import vm_manager as v
 
-def execfunc(func,guest):
+
+def execfunc(func, guest):
     try:
         out = func(guest)
     except Exception as err:
-        return f"{err.__class__.__name__}: {err}",500
+        return f"{err.__class__.__name__}: {err}", 500
     if not out:
         out = "vm_manager did not return anything, should be OK"
     return out
 
-@app.route('/')
+
+@app.route("/")
 def list_vms():
     return v.list_vms()
 
-@app.route('/status/<guest>')
+
+@app.route("/status/<guest>")
 def status_vm(guest):
     return v.status(guest)
 
-@app.route('/stop/<guest>')
+
+@app.route("/stop/<guest>")
 def stop_vm(guest):
-    out = execfunc(v.stop,guest)
+    out = execfunc(v.stop, guest)
     return out
 
-@app.route('/start/<guest>')
+
+@app.route("/start/<guest>")
 def start_vm(guest):
-    out = execfunc(v.start,guest)
+    out = execfunc(v.start, guest)
     return out
+
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0')
+    app.run(host="0.0.0.0")

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -110,7 +110,7 @@ def _create_xml(xml, vm_name):
     return ElementTree.tostring(xml_root).decode()
 
 
-def _configure_vm( vm_options ):
+def _configure_vm(vm_options):
     """
     Configure VM vm_name: set initial metadata, define libvirt xml
     configuration and add it on Pacemaker if enable is set to True.
@@ -122,7 +122,9 @@ def _configure_vm( vm_options ):
     with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
         disk_name = OS_DISK_PREFIX + vm_options["name"]
         rbd.add_image_to_group(disk_name, vm_options["name"])
-        logger.info("Image " + disk_name + " added to group " + vm_options["name"])
+        logger.info(
+            "Image " + disk_name + " added to group " + vm_options["name"]
+        )
 
         rbd.set_image_metadata(disk_name, "vm_name", vm_options["name"])
         rbd.set_image_metadata(disk_name, "xml", xml)
@@ -130,22 +132,46 @@ def _configure_vm( vm_options ):
         if "live_migration" in vm_options:
             rbd.set_image_metadata(disk_name, "_live_migration", "true")
         if "migration_user" in vm_options:
-            rbd.set_image_metadata(disk_name, "_migration_user", vm_options["migration_user"])
+            rbd.set_image_metadata(
+                disk_name, "_migration_user", vm_options["migration_user"]
+            )
         if "stop_timeout" in vm_options:
-            rbd.set_image_metadata(disk_name, "_stop_timeout", vm_options["stop_timeout"])
+            rbd.set_image_metadata(
+                disk_name, "_stop_timeout", vm_options["stop_timeout"]
+            )
         if "migrate_to_timeout" in vm_options:
-            rbd.set_image_metadata(disk_name, "_migrate_to_timeout", vm_options["migrate_to_timeout"])
+            rbd.set_image_metadata(
+                disk_name,
+                "_migrate_to_timeout",
+                vm_options["migrate_to_timeout"],
+            )
         if "migration_downtime" in vm_options:
-            rbd.set_image_metadata(disk_name, "_migration_downtime", vm_options["migration_downtime"])
+            rbd.set_image_metadata(
+                disk_name,
+                "_migration_downtime",
+                vm_options["migration_downtime"],
+            )
         if "pinned_host" in vm_options:
-            rbd.set_image_metadata(disk_name, "_pinned_host", vm_options["pinned_host"])
+            rbd.set_image_metadata(
+                disk_name, "_pinned_host", vm_options["pinned_host"]
+            )
         elif "preferred_host" in vm_options:
-            rbd.set_image_metadata(disk_name, "_preferred_host", vm_options["preferred_host"])
+            rbd.set_image_metadata(
+                disk_name, "_preferred_host", vm_options["preferred_host"]
+            )
         if "crm_config_cmd" in vm_options:
-            vm_options["crm_config_cmd_multiline"] = """{}""".format("\n".join(vm_options["crm_config_cmd"]))
-            rbd.set_image_metadata(disk_name, "_crm_config_cmd", vm_options["crm_config_cmd_multiline"])
+            vm_options["crm_config_cmd_multiline"] = """{}""".format(
+                "\n".join(vm_options["crm_config_cmd"])
+            )
+            rbd.set_image_metadata(
+                disk_name,
+                "_crm_config_cmd",
+                vm_options["crm_config_cmd_multiline"],
+            )
         if "priority" in vm_options:
-            rbd.set_image_metadata(disk_name, "_priority", vm_options["priority"])
+            rbd.set_image_metadata(
+                disk_name, "_priority", vm_options["priority"]
+            )
         if "metadata" in vm_options:
             for name, data in vm_options["metadata"].items():
                 rbd.set_image_metadata(disk_name, name, data)
@@ -158,7 +184,9 @@ def _configure_vm( vm_options ):
     logger.info("libvirt xml config defined for VM " + vm_options["name"])
 
     # Enable on Pacemaker
-    if "enable" not in vm_options or ("enable" in vm_options and vm_options["enable"]):
+    if "enable" not in vm_options or (
+        "enable" in vm_options and vm_options["enable"]
+    ):
         enable_vm(vm_options["name"])
 
 
@@ -194,7 +222,9 @@ def create(vm_options_with_nones):
     The VM will never switch to another host
     """
     # Validate parameters and required files
-    vm_options = {k: v for k, v in vm_options_with_nones.items() if v is not None}
+    vm_options = {
+        k: v for k, v in vm_options_with_nones.items() if v is not None
+    }
     _check_name(vm_options["name"])
 
     if "metadata" in vm_options:
@@ -208,10 +238,14 @@ def create(vm_options_with_nones):
         if not os.path.isfile(f):
             raise IOError(ENOENT, "Could not find file", f)
 
-    if "pinned_host" in vm_options and not Pacemaker.is_valid_host(vm_options["pinned_host"]):
+    if "pinned_host" in vm_options and not Pacemaker.is_valid_host(
+        vm_options["pinned_host"]
+    ):
         pinned_host = vm_options["pinned_host"]
         raise Exception(f"{pinned_host} is not valid hypervisor")
-    if "preferred_host" in vm_options and not Pacemaker.is_valid_host(vm_options["preferred_host"]):
+    if "preferred_host" in vm_options and not Pacemaker.is_valid_host(
+        vm_options["preferred_host"]
+    ):
         preferred_host = vm_options["preferred_host"]
         raise Exception(f"{preferred_host} is not a valid hypervisor")
 
@@ -232,7 +266,9 @@ def create(vm_options_with_nones):
             logger.info("Import qcow2 disk")
             rbd.import_qcow2(vm_options["image"], disk_name)
             if not rbd.image_exists(disk_name):
-                raise Exception("Could not import qcow2: " + vm_options["image"])
+                raise Exception(
+                    "Could not import qcow2: " + vm_options["image"]
+                )
 
             # Configure VM
             vm_options["disk_name"] = disk_name
@@ -317,7 +353,9 @@ def enable_vm(vm_name):
                 except KeyError:
                     pass
                 try:
-                    live_migration_str = rbd.get_image_metadata(disk_name, "_live_migration")
+                    live_migration_str = rbd.get_image_metadata(
+                        disk_name, "_live_migration"
+                    )
                     if live_migration_str == "true":
                         live_migration = "true"
                 except KeyError:
@@ -350,13 +388,11 @@ def enable_vm(vm_name):
                     crm_config_cmd_multi = rbd.get_image_metadata(
                         disk_name, "_crm_config_cmd"
                     )
-                    crm_config_cmd = crm_config_cmd_multi.split('\n')
+                    crm_config_cmd = crm_config_cmd_multi.split("\n")
                 except KeyError:
                     pass
                 try:
-                    priority = rbd.get_image_metadata(
-                        disk_name, "_priority"
-                    )
+                    priority = rbd.get_image_metadata(disk_name, "_priority")
                 except KeyError:
                     pass
                 try:
@@ -408,9 +444,7 @@ def enable_vm(vm_name):
                 "pacemaker_remote_port": remote_node_port,
                 "pacemaker_remote_timeout": remote_node_timeout,
             }
-            p.add_vm(
-                vm_options
-            )
+            p.add_vm(vm_options)
 
             if vm_name not in p.list_resources():
                 raise Exception(
@@ -444,7 +478,11 @@ def disable_vm(vm_name):
 
         if vm_name in p.list_resources():
             if p.show().split(" ")[0] == "FAILED":
-                logger.info("VM " + vm_name + " is in FAILED state, clean and force delete")
+                logger.info(
+                    "VM "
+                    + vm_name
+                    + " is in FAILED state, clean and force delete"
+                )
                 p.delete(force=True, clean=True)
             elif p.show().split(" ")[0] != "Stopped":
                 logger.info("VM " + vm_name + " is running, force delete")
@@ -541,7 +579,9 @@ def clone(vm_options_with_nones):
     """
     Create a new VM from another
     """
-    vm_options = {k: v for k, v in vm_options_with_nones.items() if v is not None}
+    vm_options = {
+        k: v for k, v in vm_options_with_nones.items() if v is not None
+    }
     src_vm_name = vm_options["name"]
     dst_vm_name = vm_options["dst_name"]
     if src_vm_name == dst_vm_name:
@@ -564,22 +604,36 @@ def clone(vm_options_with_nones):
 
     if "base_xml" not in vm_options:
         with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
-            vm_options["base_xml"] = rbd.get_image_metadata(src_disk, "_base_xml")
+            vm_options["base_xml"] = rbd.get_image_metadata(
+                src_disk, "_base_xml"
+            )
         if "base_xml" not in vm_options:
             raise Exception("Could not find xml libvirt configuration")
-    if "clear_constraint" not in vm_options and "preferred_host" not in vm_options and "pinned_host" not in vm_options:
+    if (
+        "clear_constraint" not in vm_options
+        and "preferred_host" not in vm_options
+        and "pinned_host" not in vm_options
+    ):
         with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
             try:
-                vm_options["preferred_host"] = rbd.get_image_metadata(src_disk, "_preferred_host")
+                vm_options["preferred_host"] = rbd.get_image_metadata(
+                    src_disk, "_preferred_host"
+                )
             except KeyError:
                 pass
             try:
-                vm_options["pinned_host"] = rbd.get_image_metadata(src_disk, "_pinned_host")
+                vm_options["pinned_host"] = rbd.get_image_metadata(
+                    src_disk, "_pinned_host"
+                )
             except KeyError:
                 pass
-    if vm_options.pinned_host and not Pacemaker.is_valid_host(vm_options.pinned_host):
+    if vm_options.pinned_host and not Pacemaker.is_valid_host(
+        vm_options.pinned_host
+    ):
         raise Exception(f"{vm_options.pinned_host} is not valid hypervisor")
-    elif vm_options.preferred_host and not Pacemaker.is_valid_host(vm_options.preferred_host):
+    elif vm_options.preferred_host and not Pacemaker.is_valid_host(
+        vm_options.preferred_host
+    ):
         raise Exception(f"{vm_options.preferred_host} is not valid hypervisor")
     if "force" not in vm_options:
         vm_options["force"] = False
@@ -593,7 +647,9 @@ def clone(vm_options_with_nones):
 
             # Note: Only deep-copy works for images that are on a group
             # (destination img will keep the snaps but not the group)
-            rbd.copy_image(src_disk, dst_disk, overwrite=vm_options["force"], deep=True)
+            rbd.copy_image(
+                src_disk, dst_disk, overwrite=vm_options["force"], deep=True
+            )
             if not rbd.image_exists(dst_disk):
                 raise Exception("Could not create image disk " + dst_disk)
             try:
@@ -843,6 +899,7 @@ def add_colocation(vm_name, *resources, strong=False):
     _check_name(vm_name)
     with Pacemaker(vm_name) as p:
         p.add_colocation(*resources, strong=strong)
+
 
 def remove_pacemaker_remote(vm_name):
     """

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -564,7 +564,8 @@ def stop(vm_name, force=False):
                 logger.info("Stop " + vm_name)
                 if force:
                     logger.info(
-                        "The option --force isn't implemented yet for cluster mode"
+                        "The option --force isn't implemented yet for cluster "
+                        "mode"
                     )
                 p.stop()
                 p.wait_for("Stopped (disabled)")

--- a/vm_manager_cmd.py
+++ b/vm_manager_cmd.py
@@ -106,7 +106,8 @@ if __name__ == "__main__":
         "--force",
         required=False,
         action="store_true",
-        help="Force VM stop (virtual unplug) - not implemented yet for cluster mode",
+        help="Force VM stop (virtual unplug) - not implemented yet for cluster"
+        " mode",
     )
 
     if vm_manager.cluster_mode:
@@ -132,8 +133,8 @@ if __name__ == "__main__":
                 action="store_true",
                 default=None,
                 required=False,
-                help="Force the VM creation and overwrites existing VM with the "
-                "same name",
+                help="Force the VM creation and overwrites existing VM with "
+                "the same name",
             )
             p.add_argument(
                 "--metadata",
@@ -177,28 +178,32 @@ if __name__ == "__main__":
                 type=str,
                 required=False,
                 default=None,
-                help="Sets the timeout in seconds for stopping a guest (default 30)",
+                help="Sets the timeout in seconds for stopping a guest "
+                "(default 30)",
             )
             p.add_argument(
                 "--migrate-to-timeout",
                 type=str,
                 required=False,
                 default=None,
-                help="Sets the timeout in seconds for live migration (default 120)",
+                help="Sets the timeout in seconds for live migration "
+                "(default 120)",
             )
             p.add_argument(
                 "--migration-downtime",
                 type=str,
                 required=False,
                 default=None,
-                help="Sets the allowed downtime for live migration in ms (default 0)",
+                help="Sets the allowed downtime for live migration in ms "
+                "(default 0)",
             )
             p.add_argument(
                 "--add-crm-config-cmd",
                 action="append",
                 required=False,
                 default=None,
-                help="Sets a crm configure command to run when enabling this guest",
+                help="Sets a crm configure command to run when enabling this "
+                "guest",
             )
             p.add_argument(
                 "--priority",
@@ -240,7 +245,8 @@ if __name__ == "__main__":
             "--date",
             type=lambda s: datetime.datetime.strptime(s, "%d/%m/%Y %H:%M:%S"),
             required=False,
-            help="Date until snapshots must be removed, i.e., 20/04/2021 14:02:32",
+            help="Date until snapshots must be removed, i.e., 20/04/2021 "
+            "14:02:32",
         )
 
         purge_parser.add_argument(
@@ -282,7 +288,8 @@ if __name__ == "__main__":
             "resources",
             type=str,
             nargs="+",
-            help="VMs or other Pacemaker resources to be colocated with the VM",
+            help="VMs or other Pacemaker resources to be colocated with the "
+            "VM",
         )
 
         add_colocation_parser.add_argument(

--- a/vm_manager_cmd.py
+++ b/vm_manager_cmd.py
@@ -81,10 +81,12 @@ if __name__ == "__main__":
             "add_colocation", help="Add a colocation constraint"
         )
         add_pacemaker_remote_parser = subparsers.add_parser(
-            "add_pacemaker_remote", help="Add a pacemaker-remote resource for the VM"
+            "add_pacemaker_remote",
+            help="Add a pacemaker-remote resource for the VM",
         )
         remove_pacemaker_remote_parser = subparsers.add_parser(
-            "remove_pacemaker_remote", help="Remove a pacemaker-remote resource for the VM"
+            "remove_pacemaker_remote",
+            help="Remove a pacemaker-remote resource for the VM",
         )
 
     for name, subparser in subparsers.choices.items():
@@ -161,7 +163,7 @@ if __name__ == "__main__":
                 "--enable-live-migration",
                 action="store_true",
                 required=False,
-                help="Enables live migration for the VM"
+                help="Enables live migration for the VM",
             )
             p.add_argument(
                 "--migration-user",
@@ -192,17 +194,17 @@ if __name__ == "__main__":
                 help="Sets the allowed downtime for live migration in ms (default 0)",
             )
             p.add_argument(
-                '--add-crm-config-cmd',
-                action='append',
+                "--add-crm-config-cmd",
+                action="append",
                 required=False,
                 default=None,
-                help='Sets a crm configure command to run when enabling this guest',
+                help="Sets a crm configure command to run when enabling this guest",
             )
             p.add_argument(
-                '--priority',
+                "--priority",
                 required=False,
                 default=None,
-                help='Sets a priority for this guest',
+                help="Sets a priority for this guest",
             )
 
         clone_parser.add_argument(
@@ -294,27 +296,26 @@ if __name__ == "__main__":
             "--remote_name",
             type=str,
             required=True,
-            help="Pacemaker remote resource name"
+            help="Pacemaker remote resource name",
         )
         add_pacemaker_remote_parser.add_argument(
             "--remote_address",
             type=str,
             required=True,
-            help="Pacemaker remote resource address or hostname"
+            help="Pacemaker remote resource address or hostname",
         )
         add_pacemaker_remote_parser.add_argument(
             "--remote_port",
             type=str,
             required=False,
-            help="Pacemaker remote resource port"
+            help="Pacemaker remote resource port",
         )
         add_pacemaker_remote_parser.add_argument(
             "--remote_timeout",
             type=str,
             required=False,
-            help="Pacemaker remote resource start timeout"
+            help="Pacemaker remote resource start timeout",
         )
-
 
     # if cluster_mode end
 
@@ -338,9 +339,9 @@ if __name__ == "__main__":
         args.live_migration = args.enable_live_migration
         args.crm_config_cmd = args.add_crm_config_cmd
         if args.disable:
-          args.enable = not args.disable
+            args.enable = not args.disable
         else:
-          args.enable = True
+            args.enable = True
         vm_manager.create(vars(args))
     elif args.command == "clone":
         args.base_xml = None

--- a/vm_manager_cmd.py
+++ b/vm_manager_cmd.py
@@ -80,6 +80,12 @@ if __name__ == "__main__":
         add_colocation_parser = subparsers.add_parser(
             "add_colocation", help="Add a colocation constraint"
         )
+        add_pacemaker_remote_parser = subparsers.add_parser(
+            "add_pacemaker_remote", help="Add a pacemaker-remote resource for the VM"
+        )
+        remove_pacemaker_remote_parser = subparsers.add_parser(
+            "remove_pacemaker_remote", help="Remove a pacemaker-remote resource for the VM"
+        )
 
     for name, subparser in subparsers.choices.items():
         if name != "list":
@@ -283,6 +289,33 @@ if __name__ == "__main__":
             required=False,
             help="Create a strong colocation constraint",
         )
+
+        add_pacemaker_remote_parser.add_argument(
+            "--remote_name",
+            type=str,
+            required=True,
+            help="Pacemaker remote resource name"
+        )
+        add_pacemaker_remote_parser.add_argument(
+            "--remote_address",
+            type=str,
+            required=True,
+            help="Pacemaker remote resource address or hostname"
+        )
+        add_pacemaker_remote_parser.add_argument(
+            "--remote_port",
+            type=str,
+            required=False,
+            help="Pacemaker remote resource port"
+        )
+        add_pacemaker_remote_parser.add_argument(
+            "--remote_timeout",
+            type=str,
+            required=False,
+            help="Pacemaker remote resource start timeout"
+        )
+
+
     # if cluster_mode end
 
     args = parser.parse_args()
@@ -344,4 +377,14 @@ if __name__ == "__main__":
     elif args.command == "add_colocation":
         vm_manager.add_colocation(
             args.name, *args.resources, strong=args.strong
+        )
+    elif args.command == "remove_pacemaker_remote":
+        vm_manager.remove_pacemaker_remote(args.name)
+    elif args.command == "add_pacemaker_remote":
+        vm_manager.add_pacemaker_remote(
+            args.name,
+            args.remote_name,
+            args.remote_address,
+            remote_node_port=args.remote_port,
+            remote_node_timeout=args.remote_timeout,
         )


### PR DESCRIPTION
Add support for the VirtualDomain remote_node meta parameter. This option can be set to inform Pacemaker that the VM have a pacemaker-remote service running on it.

pacemaker-remote offer a better monitoring and allow manage ressources inside the VM.