### PR TITLE
pacemaker: monitor stopped VM

### DIFF
--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -229,6 +229,12 @@ class Pacemaker:
             "monitor",
             "timeout='" + vm_options.get("monitor_timeout", "60") + "'",
             "interval='" + vm_options.get("monitor_interval", "10") + "'",
+            "role=Started",
+            "op",
+            "monitor",
+            "timeout='" + vm_options.get("monitor_timeout", "60") + "'",
+            "interval='" + ( str(int(vm_options.get("monitor_interval", "10")) + 1)) + "'",
+            "role=Stopped",
         ]
         if vm_options.get("pacemaker_remote"):
             args += [


### PR DESCRIPTION
Add stopped VMs monitoring to avoid leaving VMs running where they should not. Pacemaker will monitor that stopped VMs are really stopped and, if not, stop them.

Although unexpected, this situation (a VM running on two nodes) has been observed in a real cluster. This monitoring will prevent this situation from persisting.

CC: @insatomcat 

TODO:

- [x] Rebase (conflict with main)