### PR TITLE
vm_manager_cluster: fix live_migration option

### DIFF
--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -130,7 +130,7 @@ def _configure_vm(vm_options):
         rbd.set_image_metadata(disk_name, "vm_name", vm_options["name"])
         rbd.set_image_metadata(disk_name, "xml", xml)
         rbd.set_image_metadata(disk_name, "_base_xml", vm_options["base_xml"])
-        if "live_migration" in vm_options:
+        if vm_options.get("live_migration"):
             rbd.set_image_metadata(disk_name, "_live_migration", "true")
         if "migration_user" in vm_options:
             rbd.set_image_metadata(


### PR DESCRIPTION
The live_migration option is set to the value of the command line argument enable_live_migration. This argument's default value is False, thus live_migration will always be in the vm_options dictionary.

Fix condition to add the "_live_migration" metadata which should check if vm_options["live_migration"] is True rather than checking if it exists.