### PR TITLE
vm_manager: add VM disk bus option

### DIFF
--- a/vm_manager_cmd.py
+++ b/vm_manager_cmd.py
@@ -128,6 +128,15 @@ if __name__ == "__main__":
             help="Print disk import progress bar",
         )
 
+        create_parser.add_argument(
+            "--disk-bus",
+            type=str,
+            required=False,
+            default="virtio",
+            help="Set the image disk bus type in the VM, "
+            "must be a valid type recognized by libvirt (default virtio)",
+        )
+
         for p in [create_parser, clone_parser]:
             p.add_argument(
                 "--disable",


### PR DESCRIPTION
In cluster mode, add an option to the "create" command to specify the type of bus for the VM disk inside the VM.
By default vm-manager used "virtio" but not all VMs support it, such as Windows VMs for example.

This bus type is also stored as a metadata to the disk, and will be taken into account when cloning a VM.