### PR TITLE
vm_manager: set default disk bus value in create function

### DIFF
--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -300,6 +300,8 @@ def create(vm_options_with_nones):
 
             # Configure VM
             vm_options["disk_name"] = disk_name
+            if "disk_bus" not in vm_options:
+                vm_options["disk_bus"] = "virtio"
             _configure_vm(vm_options)
 
         except Exception as err:


### PR DESCRIPTION
The _configure_vm() private function expects that the vm_options array has the "disk_bus" key.
Fix the create() function so that a default value is assigned to this key if not passed to the function.