### PR TITLE
vm_manager_cmd: add console command

### DIFF
--- a/vm_manager/__init__.py
+++ b/vm_manager/__init__.py
@@ -16,6 +16,7 @@ if cluster_mode:
         stop,
         create,
         clone,
+        console,
         remove,
         enable_vm,
         disable_vm,
@@ -36,6 +37,7 @@ if cluster_mode:
 else:
     from .vm_manager_libvirt import (
         list_vms,
+        console,
         create,
         remove,
         start,

--- a/vm_manager/helpers/libvirt.py
+++ b/vm_manager/helpers/libvirt.py
@@ -6,6 +6,7 @@ Helper module to manipulate libvirt
 """
 
 import subprocess
+import sys
 import libvirt
 
 import logging
@@ -18,12 +19,12 @@ class LibVirtManager:
     A class to manage libvirt
     """
 
-    def __init__(self):
+    def __init__(self, uri="qemu:///system"):
         """
         ListVirtManager constructor. The constructor opens a connection to
         libvirt through qemu system.
         """
-        self._conn = libvirt.open("qemu:///system")
+        self._conn = libvirt.open(uri)
 
     def __enter__(self):
         """
@@ -132,6 +133,25 @@ class LibVirtManager:
                 return "Paused"
             else:
                 return "Undefined"
+
+    def console(self, vm_name):
+        """
+        Open a console on a VM
+        :param vm_name: the VM to open the console
+        """
+        uri = self._conn.getURI()
+        command = ["/usr/bin/virsh", "-c", uri, "console", vm_name]
+        logger.debug("Run: " + " ".join(command))
+        try:
+            subprocess.run(
+                command,
+                check=True,
+                stdin=sys.stdin,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            )
+        except subprocess.CalledProcessError:
+            pass
 
     @staticmethod
     def export_configuration(domain, xml_path):

--- a/vm_manager/helpers/pacemaker.py
+++ b/vm_manager/helpers/pacemaker.py
@@ -418,3 +418,23 @@ class Pacemaker:
         ret = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
         ret.wait()
         return ret.returncode == 0
+
+    @staticmethod
+    def find_resource(resource):
+        """
+        Find where a resource is running.
+        :param resource: the resource to find
+        :return: the node where the resource is running or None if the resource
+                 is not running or not found
+        """
+        command = "crm status | " + \
+            f'grep -E "^  \* {resource}\\b" | ' + \
+            "grep Started | " + \
+            "awk 'NF>1{print $NF}'"
+        ret = subprocess.run(command, shell=True, stdout=subprocess.PIPE)
+        host = ret.stdout.decode().strip()
+        if host == "":
+            logger.debug(f"Resource {resource} not found")
+            return None
+        logger.debug(f"Resource {resource} found on {host}")
+        return host

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import sys
 import logging
 import uuid
 import re
@@ -1116,3 +1117,19 @@ def add_pacemaker_remote(
             p.add_meta("remote-connect-timeout", remote_node_timeout)
         p.add_meta("remote-addr", remote_node_address)
         p.add_meta("remote-node", remote_node)
+
+
+def console(vm_name, ssh_user="admin"):
+    """
+    Open a virsh console for the given VM
+    :param vm_name: the VM name to open the console
+    """
+    # First we need to get the hypervisor where the VM is running
+    host = Pacemaker.find_resource(vm_name)
+    if not host:
+        print(f"VM {vm_name} is not running on any hypervisor", file=sys.stderr)
+        sys.exit(1)
+    libvirt_uri = f"qemu+ssh://{ssh_user}@{host}/system"
+    logger.debug(f"Opening console for VM {vm_name} on {libvirt_uri}")
+    with LibVirtManager(uri=libvirt_uri) as lvm:
+        lvm.console(vm_name)

--- a/vm_manager/vm_manager_cmd.py
+++ b/vm_manager/vm_manager_cmd.py
@@ -48,6 +48,8 @@ def main():
     stop_parser = subparsers.add_parser("stop", help="Stop a VM")
     subparsers.add_parser("list", help="List all VMs")
     subparsers.add_parser("status", help="Print VM status")
+    console_parser = subparsers.add_parser("console", help="Connect to a VM console")
+
 
     if vm_manager.cluster_mode:
         clone_parser = subparsers.add_parser("clone", help="Clone a VM")
@@ -90,7 +92,7 @@ def main():
         )
 
     for name, subparser in subparsers.choices.items():
-        if name != "list":
+        if name not in ("list", "console"):
             subparser.add_argument(
                 "-n",
                 "--name",
@@ -108,6 +110,11 @@ def main():
         action="store_true",
         help="Force VM stop (virtual unplug) - not implemented yet for cluster"
         " mode",
+    )
+    console_parser.add_argument(
+        "name",
+        type=str,
+        help="The VM name",
     )
 
     if vm_manager.cluster_mode:
@@ -394,6 +401,13 @@ def main():
             required=False,
             help="Pacemaker remote resource start timeout",
         )
+        console_parser.add_argument(
+            "--ssh-user",
+            type=str,
+            required=False,
+            default="admin",
+            help="SSH user to connect to the VM",
+        )
 
     # if cluster_mode end
 
@@ -467,6 +481,11 @@ def main():
             remote_node_port=args.remote_port,
             remote_node_timeout=args.remote_timeout,
         )
+    elif args.command == "console":
+        if vm_manager.cluster_mode:
+            vm_manager.console(args.name, args.ssh_user)
+        else:
+            vm_manager.console(args.name)
 
 if __name__ == "__main__":
     main()

--- a/vm_manager/vm_manager_libvirt.py
+++ b/vm_manager/vm_manager_libvirt.py
@@ -106,3 +106,11 @@ def status(vm_name):
     """
     with LibVirtManager() as lvm:
         return lvm.status(vm_name)
+
+def console(vm_name):
+    """
+    Open a virsh console for the given VM
+    :param vm_name: the VM name to open the console
+    """
+    with LibVirtManager() as lvm:
+        lvm.console(vm_name)


### PR DESCRIPTION
The console command allows opening a console on a VM. It is available in both cluster and standalone mode on the command line only.

It uses the virsh console command to open a console on the VM. On cluster mode, it first finds the hypervisor where the VM is running using the Pacemaker helper.

To be used on cluster mode it required to have an SSH connection to the hypervisor where the VM is running. The user can be specified with the --ssh-user option.