### PR TITLE
Fixing timezone issue

### DIFF
--- a/vm_manager/helpers/tests/rbd_manager/rollback_rbd.py
+++ b/vm_manager/helpers/tests/rbd_manager/rollback_rbd.py
@@ -85,7 +85,7 @@ def main():
             ts = rbd.get_image_snapshot_timestamp(IMG_NAME, SNAP)
             print("Snapshot " + SNAP + " timestamp: " + str(ts))
             if (
-                int(ts.timestamp()) > int(time.time()) + 5
+                int(ts.timestamp()) - time.timezone > int(time.time()) + 5
             ):  # Compare with 5 sec delay
                 raise Exception(
                     "Incorrect snapshot " + SNAP + " timestamp: " + str(ts)


### PR DESCRIPTION
The rollback_rbd test comapres timestemps from two diffent sources, However one returns UTC time and the other local timezone time. In timezones with a positive offset this will cause the test to fail unless we correct for the offset.