### PR TITLE
Properly close connection to Rados

### DIFF
--- a/vm_manager/helpers/rbd_manager.py
+++ b/vm_manager/helpers/rbd_manager.py
@@ -69,6 +69,7 @@ class RbdManager:
         Close I/O context.
         """
         self._ioctx.close()
+        self._cluster.shutdown()
 
     # Namespace methods
     def list_namespaces(self):


### PR DESCRIPTION
When using the rest api, gunicorn rarely kills the worker so we need to properly release the connection to Rados otherwise we hit a "Too many open files" error.