### PR TITLE
Fix snapshot timestamp comparison across Python versions

### DIFF
--- a/vm_manager/helpers/tests/rbd_manager/rollback_rbd.py
+++ b/vm_manager/helpers/tests/rbd_manager/rollback_rbd.py
@@ -83,9 +83,12 @@ def main():
 
             # Check snapshot timestamp
             ts = rbd.get_image_snapshot_timestamp(IMG_NAME, SNAP)
+            if ts.tzinfo is None:
+                from datetime import timezone
+                ts = ts.replace(tzinfo=timezone.utc)
             print("Snapshot " + SNAP + " timestamp: " + str(ts))
             if (
-                int(ts.timestamp()) - time.timezone > int(time.time()) + 5
+                int(ts.timestamp()) > int(time.time()) + 5
             ):  # Compare with 5 sec delay
                 raise Exception(
                     "Incorrect snapshot " + SNAP + " timestamp: " + str(ts)


### PR DESCRIPTION
The rbd.get_image_snapshot_timestamp() method returns timezone-aware datetimes in Python 3.13 but timezone-naive datetimes in Python 3.9. When naive, the timestamp is interpreted as local time instead of UTC, causing incorrect comparisons with time.time().

Explicitly set tzinfo to UTC for naive datetimes to ensure consistent timestamp interpretation across all Python versions and system timezones.