### PR TITLE
vm_manager_cluster: user libvirtadmin for console

### DIFF
--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -1139,7 +1139,7 @@ def add_pacemaker_remote(
         p.add_meta("remote-node", remote_node)
 
 
-def console(vm_name, ssh_user="admin"):
+def console(vm_name, ssh_user="libvirtadmin"):
     """
     Open a virsh console for the given VM
     :param vm_name: the VM name to open the console

--- a/vm_manager/vm_manager_cmd.py
+++ b/vm_manager/vm_manager_cmd.py
@@ -426,7 +426,7 @@ def main():
             "--ssh-user",
             type=str,
             required=False,
-            default="admin",
+            default="libvirtadmin",
             help="SSH user to connect to the VM",
         )
 


### PR DESCRIPTION
Use the libvirtadmin user instead of admin as default user for the console.
The libvirtadmin user is a renaming from the livemigration user.