### PR TITLE
Allow predefined VM UUIDs

### DIFF
--- a/tests/test_vm_manager_cluster.py
+++ b/tests/test_vm_manager_cluster.py
@@ -252,11 +252,19 @@ class TestCreateXml:
         result = vmc._create_xml(xml, "myvm")
         assert "<name>myvm</name>" in result
 
-    def test_uuid_replaced(self):
+    def test_uuid_preserved_when_provided(self):
         xml = _read_test_xml()
         result = vmc._create_xml(xml, "myvm")
-        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" not in result
+        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" in result
+
+    def test_uuid_generated_when_not_provided(self):
+        xml = _read_test_xml()
+        xml = xml.replace(
+            "<uuid>7b48b1fe-066a-41a6-aef4-f0a9c028f719</uuid>", ""
+        )
+        result = vmc._create_xml(xml, "myvm")
         assert "<uuid>" in result
+        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" not in result
 
     def test_rbd_disk_added(self):
         xml = _read_test_xml()

--- a/tests/test_vm_manager_libvirt.py
+++ b/tests/test_vm_manager_libvirt.py
@@ -19,13 +19,22 @@ class TestCreateXml:
         result = vml._create_xml(xml, "myvm")
         assert "<name>myvm</name>" in result
 
-    def test_uuid_replaced(self, vm_xml_path):
+    def test_uuid_preserved_when_provided(self, vm_xml_path):
         with open(vm_xml_path) as f:
             xml = f.read()
         result = vml._create_xml(xml, "myvm")
-        # Original UUID should be gone
-        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" not in result
+        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" in result
+
+    def test_uuid_generated_when_not_provided(self, vm_xml_path):
+        with open(vm_xml_path) as f:
+            xml = f.read()
+        # Remove the uuid element from the XML
+        xml = xml.replace(
+            "<uuid>7b48b1fe-066a-41a6-aef4-f0a9c028f719</uuid>", ""
+        )
+        result = vml._create_xml(xml, "myvm")
         assert "<uuid>" in result
+        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" not in result
 
 
 class TestCreate:

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -113,13 +113,18 @@ def _create_xml(xml, vm_name, target_disk_bus="virtio"):
     xml_root = ElementTree.fromstring(xml)
     try:
         xml_root.remove(xml_root.findall("./name")[0])
-        xml_root.remove(xml_root.findall("./uuid")[0])
     except IndexError:
         pass
+    existing_uuid = xml_root.findall("./uuid")
+    if not existing_uuid or not existing_uuid[0].text:
+        try:
+            xml_root.remove(existing_uuid[0])
+        except IndexError:
+            pass
+        uuid_element = ElementTree.SubElement(xml_root, "uuid")
+        uuid_element.text = str(uuid.uuid4())
     name_element = ElementTree.SubElement(xml_root, "name")
     name_element.text = vm_name
-    name_element = ElementTree.SubElement(xml_root, "uuid")
-    name_element.text = str(uuid.uuid4())
     rbd_secret = None
     hosts_list = _get_ceph_hosts_xml()
     with LibVirtManager() as libvirt_manager:
@@ -429,6 +434,12 @@ def add_to_cluster(vm_options_with_nones):
         raise Exception(
             "Could not determine disk image path from VM " + src_name
         )
+    # Remove UUID when renaming to avoid conflicts with the source VM
+    if target_name != src_name:
+        existing_uuid = xml_root.find("uuid")
+        if existing_uuid is not None:
+            xml_root.remove(existing_uuid)
+
     clean_xml = ElementTree.tostring(xml_root, encoding="unicode")
 
     # If keeping the same name, remove from libvirt first to avoid conflicts

--- a/vm_manager/vm_manager_libvirt.py
+++ b/vm_manager/vm_manager_libvirt.py
@@ -30,13 +30,18 @@ def _create_xml(xml, vm_name):
     xml_root = ElementTree.fromstring(xml)
     try:
         xml_root.remove(xml_root.findall("./name")[0])
-        xml_root.remove(xml_root.findall("./uuid")[0])
     except IndexError:
         pass
+    existing_uuid = xml_root.findall("./uuid")
+    if not existing_uuid or not existing_uuid[0].text:
+        try:
+            xml_root.remove(existing_uuid[0])
+        except IndexError:
+            pass
+        uuid_element = ElementTree.SubElement(xml_root, "uuid")
+        uuid_element.text = str(uuid.uuid4())
     name_element = ElementTree.SubElement(xml_root, "name")
     name_element.text = vm_name
-    name_element = ElementTree.SubElement(xml_root, "uuid")
-    name_element.text = str(uuid.uuid4())
 
     return ElementTree.tostring(xml_root).decode()
 


### PR DESCRIPTION
Hello to All,

Although guest.xml.j2 read the variable vm.uuid, this value was later discarded by vm_manager. This behavior is fixed, permitting redeployment of applications binding their licenses to this UUID.

Best regards, 
Daniel