### PR TITLE
Additional ceph disks for clusters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: pip install ".[test]"
 
       - name: Run tests
-        run: sg libvirt -c "pytest tests/ -v --tb=short --ignore=tests/test_vm_manager_cluster.py"
+        run: sg libvirt -c "pytest tests/ -v --tb=short --ignore=tests/test_vm_manager_cluster.py --ignore=tests/test_vm_manager_cmd_cluster.py"
 
       - name: Install documentation dependencies
         run: pip install ".[docs]"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,6 @@ Test scripts are in `vm_manager/helpers/tests/pacemaker/` and `vm_manager/helper
 - **License**: Apache-2.0 (all source files have copyright headers)
 - **Code review**: Gerrit (`.gitreview` → `g1.sfl.team`)
 - **VM naming**: alphanumeric only, validated by `_check_name()`
-- **Disk naming**: system disks prefixed with `system_` (`OS_DISK_PREFIX` constant)
+- **Disk naming**: system disks prefixed with `system_` (`OS_DISK_PREFIX`), additional disks prefixed with `data_` (`DATA_DISK_PREFIX`), e.g. `data_guest0_0`
 - **Flake8 config** (`.flake8`): ignores F401 in `__init__.py`, E501 and W503 globally
 - **Custom exceptions**: `RbdException`, `PacemakerException`

--- a/tests/test_vm_manager_cluster.py
+++ b/tests/test_vm_manager_cluster.py
@@ -85,6 +85,27 @@ def qcow2_image():
 
 
 @pytest.fixture
+def additional_qcow2_images():
+    """Create two small temporary qcow2 images for additional disk testing."""
+    paths = []
+    for _ in range(2):
+        with tempfile.NamedTemporaryFile(suffix=".qcow2", delete=False) as f:
+            path = f.name
+        subprocess.run(
+            ["qemu-img", "create", "-f", "qcow2", path, "64M"],
+            check=True,
+            capture_output=True,
+        )
+        paths.append(path)
+    yield paths
+    for p in paths:
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
+
+
+@pytest.fixture
 def created_vm(vm_name, qcow2_image):
     """Create a VM and return its name. Enables by default."""
     xml = _read_test_xml()
@@ -93,6 +114,23 @@ def created_vm(vm_name, qcow2_image):
             "name": vm_name,
             "image": qcow2_image,
             "base_xml": xml,
+        }
+    )
+    return vm_name
+
+
+@pytest.fixture
+def created_vm_with_additional_disks(
+    vm_name, qcow2_image, additional_qcow2_images
+):
+    """Create a VM with additional disks and return its name."""
+    xml = _read_test_xml()
+    vmc.create(
+        {
+            "name": vm_name,
+            "image": qcow2_image,
+            "base_xml": xml,
+            "additional_disks": additional_qcow2_images,
         }
     )
     return vm_name
@@ -521,7 +559,7 @@ class TestSnapshots:
         with pytest.raises(ValueError, match="not datetime"):
             vmc.purge_image("vm", date="2025-01-01")
 
-        with pytest.raises(ValueError, match="positive integer"):
+        with pytest.raises(ValueError, match="non-negative integer"):
             vmc.purge_image("vm", number=-1)
 
 
@@ -693,6 +731,150 @@ class TestAddToCluster:
             with LibVirtManager() as lvm:
                 if vm_name in lvm.list():
                     lvm.undefine(vm_name)
+
+
+# ── additional disks ─────────────────────────────────────────────────
+
+
+class TestAdditionalDisksCreate:
+    def test_create_with_additional_disks(
+        self, created_vm_with_additional_disks
+    ):
+        assert created_vm_with_additional_disks in vmc.list_vms()
+
+    def test_create_with_additional_disks_force(
+        self,
+        created_vm_with_additional_disks,
+        qcow2_image,
+        additional_qcow2_images,
+    ):
+        vmc.create(
+            {
+                "name": created_vm_with_additional_disks,
+                "image": qcow2_image,
+                "base_xml": _read_test_xml(),
+                "additional_disks": additional_qcow2_images,
+                "force": True,
+            }
+        )
+        assert created_vm_with_additional_disks in vmc.list_vms()
+
+    def test_create_additional_disk_missing_file_raises(
+        self, vm_name, qcow2_image
+    ):
+        with pytest.raises(IOError):
+            vmc.create(
+                {
+                    "name": vm_name,
+                    "image": qcow2_image,
+                    "base_xml": _read_test_xml(),
+                    "additional_disks": ["/nonexistent/disk.qcow2"],
+                }
+            )
+
+
+class TestAdditionalDisksRemove:
+    def test_remove_vm_with_additional_disks(
+        self, vm_name, qcow2_image, additional_qcow2_images
+    ):
+        vmc.create(
+            {
+                "name": vm_name,
+                "image": qcow2_image,
+                "base_xml": _read_test_xml(),
+                "additional_disks": additional_qcow2_images,
+            }
+        )
+        vmc.remove(vm_name)
+        assert vmc.status(vm_name) == "Undefined"
+
+
+class TestAdditionalDisksSnapshot:
+    def test_create_snapshot(self, created_vm_with_additional_disks):
+        vmc.create_snapshot(created_vm_with_additional_disks, "snap1")
+        assert "snap1" in vmc.list_snapshots(created_vm_with_additional_disks)
+
+    def test_remove_snapshot(self, created_vm_with_additional_disks):
+        vmc.create_snapshot(created_vm_with_additional_disks, "snap1")
+        vmc.remove_snapshot(created_vm_with_additional_disks, "snap1")
+        assert "snap1" not in vmc.list_snapshots(
+            created_vm_with_additional_disks
+        )
+
+    def test_rollback_snapshot(self, created_vm_with_additional_disks):
+        vmc.create_snapshot(created_vm_with_additional_disks, "snap1")
+        vmc.rollback_snapshot(created_vm_with_additional_disks, "snap1")
+
+    def test_purge_all_snapshots(self, created_vm_with_additional_disks):
+        vmc.create_snapshot(created_vm_with_additional_disks, "snap1")
+        vmc.create_snapshot(created_vm_with_additional_disks, "snap2")
+        vmc.purge_image(created_vm_with_additional_disks)
+        assert len(vmc.list_snapshots(created_vm_with_additional_disks)) == 0
+
+
+class TestAdditionalDisksClone:
+    def test_clone_vm_with_additional_disks(
+        self, created_vm_with_additional_disks, second_vm_name
+    ):
+        vmc.clone(
+            {
+                "name": created_vm_with_additional_disks,
+                "dst_name": second_vm_name,
+            }
+        )
+        assert second_vm_name in vmc.list_vms()
+        # Verify additional disks were cloned: snapshot operates on all
+        # disks in the Ceph group — would fail if additional disks are
+        # missing from the clone's group
+        vmc.create_snapshot(second_vm_name, "verifysnap")
+        vmc.remove_snapshot(second_vm_name, "verifysnap")
+
+    def test_clone_snapshot_preserved(
+        self, created_vm_with_additional_disks, second_vm_name
+    ):
+        vmc.create_snapshot(created_vm_with_additional_disks, "snap1")
+        vmc.clone(
+            {
+                "name": created_vm_with_additional_disks,
+                "dst_name": second_vm_name,
+            }
+        )
+        assert "snap1" in vmc.list_snapshots(second_vm_name)
+
+
+class TestAdditionalDisksCreateXml:
+    def test_additional_disks_in_xml(self):
+        xml = _read_test_xml()
+        result = vmc._create_xml(
+            xml, "myvm", additional_disks=["data_myvm_0", "data_myvm_1"]
+        )
+        root = ElementTree.fromstring(result)
+        disks = root.findall(".//disk[@type='network']")
+        assert len(disks) == 3  # system + 2 additional
+
+    def test_additional_disk_dev_names(self):
+        xml = _read_test_xml()
+        result = vmc._create_xml(
+            xml, "myvm", additional_disks=["data_myvm_0", "data_myvm_1"]
+        )
+        root = ElementTree.fromstring(result)
+        targets = [
+            d.find("target").get("dev")
+            for d in root.findall(".//disk[@type='network']")
+        ]
+        assert targets == ["vda", "vdb", "vdc"]
+
+    def test_no_additional_disks(self):
+        xml = _read_test_xml()
+        result = vmc._create_xml(xml, "myvm")
+        root = ElementTree.fromstring(result)
+        disks = root.findall(".//disk[@type='network']")
+        assert len(disks) == 1
+
+    def test_additional_disk_ceph_source(self):
+        xml = _read_test_xml()
+        result = vmc._create_xml(xml, "myvm", additional_disks=["data_myvm_0"])
+        assert "data_myvm_0" in result
 
 
 # ── console ──────────────────────────────────────────────────────────

--- a/tests/test_vm_manager_cmd.py
+++ b/tests/test_vm_manager_cmd.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2026, Sprecher Automation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Argparse-only tests for the vm_manager_cmd CLI.
+
+These tests exercise the argparse layer in isolation and have no
+cluster dependencies. The end-to-end test that drives main() through
+the real backend lives in test_vm_manager_cmd_cluster.py (which CI
+ignores because it needs Ceph/Pacemaker).
+"""
+
+import pytest
+
+import vm_manager
+from vm_manager.vm_manager_cmd import get_parser
+
+pytestmark = pytest.mark.skipif(
+    not vm_manager.cluster_mode,
+    reason="--additional-disk is only registered in cluster mode",
+)
+
+
+BASE_CREATE_ARGS = [
+    "create",
+    "--name",
+    "vm1",
+    "--xml",
+    "/nonexistent/vm.xml",
+    "-i",
+    "/nonexistent/sys.qcow2",
+]
+
+
+class TestCreateAdditionalDiskFlag:
+    def test_single_additional_disk_parses_to_list(self):
+        parser = get_parser()
+        args = parser.parse_args(
+            BASE_CREATE_ARGS + ["--additional-disk", "/nonexistent/a.qcow2"]
+        )
+        assert args.additional_disks == ["/nonexistent/a.qcow2"]
+
+    def test_multiple_additional_disks_accumulate_in_order(self):
+        parser = get_parser()
+        args = parser.parse_args(
+            BASE_CREATE_ARGS
+            + [
+                "--additional-disk",
+                "/nonexistent/a.qcow2",
+                "--additional-disk",
+                "/nonexistent/b.qcow2",
+                "--additional-disk",
+                "/nonexistent/c.qcow2",
+            ]
+        )
+        assert args.additional_disks == [
+            "/nonexistent/a.qcow2",
+            "/nonexistent/b.qcow2",
+            "/nonexistent/c.qcow2",
+        ]
+
+    def test_omitted_flag_defaults_to_none(self):
+        parser = get_parser()
+        args = parser.parse_args(BASE_CREATE_ARGS)
+        assert args.additional_disks is None
+
+    def test_additional_disk_singular_attr_not_used(self):
+        """Guard against accidentally dropping dest= — without it,
+        argparse would derive args.additional_disk (singular) and the
+        backend would never see the list.
+        """
+        parser = get_parser()
+        args = parser.parse_args(
+            BASE_CREATE_ARGS + ["--additional-disk", "/nonexistent/a.qcow2"]
+        )
+        assert not hasattr(args, "additional_disk")

--- a/tests/test_vm_manager_cmd_cluster.py
+++ b/tests/test_vm_manager_cmd_cluster.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2026, Sprecher Automation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end test for the vm_manager_cmd CLI against a real cluster.
+
+Requires Ceph + Pacemaker — the GitHub Actions CI workflow ignores
+this file for that reason (see .github/workflows/ci.yml).
+
+The test drives main() through the real backend without mocking
+vm_manager.create(), which is the only way to prove that the string
+'additional_disks' is consistent between vm_manager_cmd.py (dest=) and
+vm_manager_cluster.py (vm_options.get).
+"""
+
+import os
+import secrets
+import subprocess
+import xml.etree.ElementTree as ElementTree
+
+import pytest
+
+from vm_manager import vm_manager_cluster as vmc
+from vm_manager.helpers.rbd_manager import RbdManager
+from vm_manager.vm_manager_cluster import CEPH_CONF, NAMESPACE, POOL_NAME
+from vm_manager.vm_manager_cmd import main
+
+
+TESTDATA_XML_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "vm_manager",
+    "testdata",
+    "vm.xml",
+)
+
+
+def _read_test_xml_no_uuid():
+    """Read the test VM template and strip the UUID to avoid collisions
+    with VMs already present on the cluster from other tests.
+    """
+    with open(TESTDATA_XML_PATH) as f:
+        xml = f.read()
+    root = ElementTree.fromstring(xml)
+    uuid_el = root.find("uuid")
+    if uuid_el is not None:
+        root.remove(uuid_el)
+    return ElementTree.tostring(root, encoding="unicode")
+
+
+@pytest.fixture
+def cli_vm_name():
+    """Unique VM name with teardown via vmc.remove."""
+    name = "testvm" + secrets.token_hex(4)
+    yield name
+    try:
+        vmc.remove(name)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def cli_qcow2_image(tmp_path):
+    """Small temporary qcow2 image for the system disk."""
+    path = tmp_path / "sys.qcow2"
+    subprocess.run(
+        ["qemu-img", "create", "-f", "qcow2", str(path), "64M"],
+        check=True,
+        capture_output=True,
+    )
+    return str(path)
+
+
+@pytest.fixture
+def cli_additional_qcow2_images(tmp_path):
+    """Two small temporary qcow2 images for additional disks."""
+    paths = []
+    for i in range(2):
+        path = tmp_path / f"data{i}.qcow2"
+        subprocess.run(
+            ["qemu-img", "create", "-f", "qcow2", str(path), "64M"],
+            check=True,
+            capture_output=True,
+        )
+        paths.append(str(path))
+    return paths
+
+
+class TestCreateAdditionalDiskEndToEnd:
+    def test_cli_create_with_additional_disks(
+        self,
+        monkeypatch,
+        tmp_path,
+        cli_vm_name,
+        cli_qcow2_image,
+        cli_additional_qcow2_images,
+    ):
+        xml_file = tmp_path / "vm.xml"
+        xml_file.write_text(_read_test_xml_no_uuid())
+
+        argv = [
+            "vm_manager_cmd",
+            "create",
+            "--name",
+            cli_vm_name,
+            "--xml",
+            str(xml_file),
+            "-i",
+            cli_qcow2_image,
+            "--additional-disk",
+            cli_additional_qcow2_images[0],
+            "--additional-disk",
+            cli_additional_qcow2_images[1],
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        main()
+
+        assert cli_vm_name in vmc.list_vms()
+
+        with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
+            group_images = rbd.list_group_images(cli_vm_name)
+
+        assert f"system_{cli_vm_name}" in group_images
+        assert f"data_{cli_vm_name}_0" in group_images
+        assert f"data_{cli_vm_name}_1" in group_images

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -27,12 +27,18 @@ NAMESPACE = ""
 
 RESERVED_NAMES = ["xml"]
 OS_DISK_PREFIX = "system_"
+DATA_DISK_PREFIX = "data_"
 
 logger = logging.getLogger(__name__)
 
 """
 A module to manage VMs in Seapath cluster.
 """
+
+
+def _additional_disk_name(index, vm_name):
+    """Return the Ceph image name for an additional disk."""
+    return DATA_DISK_PREFIX + vm_name + "_" + str(index)
 
 
 def list_all_uuids():
@@ -120,7 +126,7 @@ def _get_ceph_hosts_xml(port=6789):
     return xml_lines
 
 
-def _create_xml(xml, vm_name, target_disk_bus="virtio"):
+def _create_xml(xml, vm_name, target_disk_bus="virtio", additional_disks=None):
     """
     Creates a libvirt configuration file according to xml and
     disk_name parameters.
@@ -131,6 +137,8 @@ def _create_xml(xml, vm_name, target_disk_bus="virtio"):
     :param: target_disk_bus: bus type of the VM system disk inside the VM.
             Should be a valid type recognized by libvirt, see https://libvirt.org/formatdomain.html#devices.
             Default: virtio
+    :param: additional_disks: optional list of Ceph image names.
+        Each entry produces an additional RBD disk element.
     """
     disk_name = OS_DISK_PREFIX + vm_name
     xml_root = prepare_xml_base(xml, vm_name)
@@ -160,6 +168,34 @@ def _create_xml(xml, vm_name, target_disk_bus="virtio"):
         )
     )
     xml_root.find("devices").append(disk_xml)
+
+    # Append additional RBD disks
+    if additional_disks:
+        for i, ceph_image in enumerate(additional_disks):
+            dev_letter = chr(ord("b") + i)
+            extra_disk_xml = ElementTree.fromstring(
+                """
+<disk type="network" device="disk">
+  <driver name="qemu" type="raw" cache="writeback" />
+  <auth username="libvirt">
+    <secret type="ceph" uuid="{}" />
+  </auth>
+  <source protocol="rbd" name="{}/{}">
+    {}
+  </source>
+  <target dev="vd{}" bus="{}" />
+</disk>
+""".format(
+                    rbd_secret,
+                    POOL_NAME,
+                    ceph_image,
+                    hosts_list,
+                    dev_letter,
+                    target_disk_bus,
+                )
+            )
+            xml_root.find("devices").append(extra_disk_xml)
+
     ElementTree.indent(xml_root, space="  ")
     return ElementTree.tostring(xml_root, encoding="unicode")
 
@@ -170,8 +206,21 @@ def _configure_vm(vm_options):
     configuration and add it on Pacemaker if enable is set to True.
     """
 
+    # Build list of additional Ceph disk names for XML generation
+    additional_count = vm_options.get(
+        "_known_additional_count",
+        len(vm_options.get("additional_disks", [])),
+    )
+    additional_ceph_disks = [
+        _additional_disk_name(i, vm_options["name"])
+        for i in range(additional_count)
+    ]
+
     xml = _create_xml(
-        vm_options["base_xml"], vm_options["name"], vm_options["disk_bus"]
+        vm_options["base_xml"],
+        vm_options["name"],
+        vm_options["disk_bus"],
+        additional_disks=additional_ceph_disks or None,
     )
 
     # Add to group and set initial metadata
@@ -181,6 +230,13 @@ def _configure_vm(vm_options):
         logger.info(
             "Image " + disk_name + " added to group " + vm_options["name"]
         )
+
+        # Add additional disks to the group
+        for ceph_name in additional_ceph_disks:
+            rbd.add_image_to_group(ceph_name, vm_options["name"])
+            logger.info(
+                "Image " + ceph_name + " added to group " + vm_options["name"]
+            )
 
         rbd.set_image_metadata(disk_name, "vm_name", vm_options["name"])
         rbd.set_image_metadata(disk_name, "xml", xml)
@@ -246,6 +302,14 @@ def _configure_vm(vm_options):
                     f"_{pacemaker_arg}",
                     json.dumps(vm_options[pacemaker_arg]),
                 )
+
+        # Store additional disk count as metadata on the system disk
+        if additional_ceph_disks:
+            rbd.set_image_metadata(
+                disk_name,
+                "_additional_disks",
+                json.dumps(len(additional_ceph_disks)),
+            )
 
     logger.info("Image " + disk_name + " initial metadata set")
 
@@ -337,7 +401,9 @@ def create(vm_options_with_nones):
                         f"{pacemaker_arg} parameter must be a dictionary"
                     )
 
-    for f in [CEPH_CONF, vm_options["image"]]:
+    files_to_check = [CEPH_CONF, vm_options["image"]]
+    files_to_check.extend(vm_options.get("additional_disks", []))
+    for f in files_to_check:
         if not os.path.isfile(f):
             raise IOError(ENOENT, "Could not find file", f)
 
@@ -378,14 +444,27 @@ def create(vm_options_with_nones):
             if rbd.image_exists(disk_name):
                 rbd.remove_image(disk_name)
 
-            # Import qcow2 disk
+            # Import qcow2 system disk
             logger.info("Import qcow2 disk")
             rbd.import_qcow2(vm_options["image"], disk_name, progress)
             if not rbd.image_exists(disk_name):
-                raise Exception(
+                raise RuntimeError(
                     "Could not import qcow2: " + vm_options["image"]
                 )
 
+            # Import additional disks
+            for i, filepath in enumerate(
+                vm_options.get("additional_disks", [])
+            ):
+                add_disk_name = _additional_disk_name(i, vm_options["name"])
+                if rbd.image_exists(add_disk_name):
+                    rbd.remove_image(add_disk_name)
+                logger.info(
+                    "Import additional disk %s as %s", filepath, add_disk_name
+                )
+                rbd.import_qcow2(filepath, add_disk_name, progress)
+                if not rbd.image_exists(add_disk_name):
+                    raise RuntimeError("Could not import qcow2: " + filepath)
             # Configure VM
             vm_options["disk_name"] = disk_name
             if "disk_bus" not in vm_options:
@@ -488,21 +567,32 @@ def remove(vm_name):
         if vm_name in lvm.list():
             lvm.undefine(vm_name)
 
-    # Remove group and image from RBD cluster
+    # Remove group and all images from RBD cluster
     with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
 
         disk_name = OS_DISK_PREFIX + vm_name
+
+        # Collect all images in the group before removing the group
+        all_images = []
         if rbd.group_exists(vm_name):
+            all_images = rbd.list_group_images(vm_name)
             rbd.remove_group(vm_name)
 
-        if rbd.image_exists(disk_name):
-            rbd.remove_image(disk_name)
+        # Ensure system disk is in the removal list
+        if disk_name not in all_images:
+            all_images.append(disk_name)
+
+        # Remove all images
+        for img in all_images:
+            if rbd.image_exists(img):
+                rbd.remove_image(img)
 
         if rbd.group_exists(vm_name):
             raise Exception("Could not remove group " + vm_name)
 
-        if rbd.image_exists(disk_name):
-            raise Exception("Could not remove image " + disk_name)
+        for img in all_images:
+            if rbd.image_exists(img):
+                raise RuntimeError("Could not remove image " + img)
 
     logger.info("VM " + vm_name + " removed")
 
@@ -937,6 +1027,41 @@ def clone(vm_options_with_nones):
             )
             if not rbd.image_exists(dst_disk):
                 raise Exception("Could not create image disk " + dst_disk)
+
+            # Copy additional disks from source VM
+            src_additional_count = 0
+            try:
+                src_additional_count = json.loads(
+                    rbd.get_image_metadata(src_disk, "_additional_disks")
+                )
+            except KeyError:
+                pass
+
+            for i in range(src_additional_count):
+                src_add_disk = _additional_disk_name(i, src_vm_name)
+                dst_add_disk = _additional_disk_name(i, dst_vm_name)
+                if rbd.image_exists(dst_add_disk):
+                    rbd.remove_image(dst_add_disk)
+                logger.info(
+                    "Clone additional disk %s -> %s",
+                    src_add_disk,
+                    dst_add_disk,
+                )
+                rbd.copy_image(
+                    src_add_disk,
+                    dst_add_disk,
+                    overwrite=vm_options["force"],
+                    deep=True,
+                )
+                if not rbd.image_exists(dst_add_disk):
+                    raise RuntimeError(
+                        "Could not clone additional disk " + dst_add_disk
+                    )
+
+            # Pass known additional count so _configure_vm can set up XML + group
+            if src_additional_count:
+                vm_options["_known_additional_count"] = src_additional_count
+
             for disk_metadata in (
                 "_preferred_host",
                 "_pinned_host",
@@ -972,19 +1097,43 @@ def clone(vm_options_with_nones):
                 )
                 vm_options["disk_bus"] = "virtio"
 
-            # Configure VM
+            # Configure VM — strip source UUID so the clone gets a new one
             vm_options["name"] = dst_vm_name
+            base_root = ElementTree.fromstring(vm_options["base_xml"])
+            for old_uuid in base_root.findall("./uuid"):
+                base_root.remove(old_uuid)
+            vm_options["base_xml"] = ElementTree.tostring(
+                base_root, encoding="unicode"
+            )
             _configure_vm(vm_options)
 
         except Exception as err:
             remove(dst_vm_name)
             if not rbd.is_image_in_group(src_disk, src_vm_name):
                 rbd.add_image_to_group(src_disk, src_vm_name)
+            # Re-add source additional disks to source group if needed
+            for i in range(src_additional_count):
+                src_add_disk = _additional_disk_name(i, src_vm_name)
+                try:
+                    if not rbd.is_image_in_group(src_add_disk, src_vm_name):
+                        rbd.add_image_to_group(src_add_disk, src_vm_name)
+                except Exception:
+                    pass
             raise err
 
     logger.info(
         "VM " + src_vm_name + " successfully cloned into " + dst_vm_name
     )
+
+
+def _get_all_disk_names(rbd, vm_name):
+    """
+    Return all Ceph image names belonging to a VM.
+    Uses the group if it exists, otherwise falls back to the system disk only.
+    """
+    if rbd.group_exists(vm_name):
+        return rbd.list_group_images(vm_name)
+    return [OS_DISK_PREFIX + vm_name]
 
 
 def create_snapshot(vm_name, snapshot_name):
@@ -1000,22 +1149,28 @@ def create_snapshot(vm_name, snapshot_name):
 
     with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
 
-        disk_name = OS_DISK_PREFIX + vm_name
-        if rbd.image_snapshot_exists(disk_name, snapshot_name):
-            raise Exception(
+        disk_names = _get_all_disk_names(rbd, vm_name)
+
+        # Validate that no snapshot with this name exists on any disk
+        for disk_name in disk_names:
+            if rbd.image_snapshot_exists(disk_name, snapshot_name):
+                raise Exception(
+                    "Snapshot "
+                    + snapshot_name
+                    + " already exists on image "
+                    + disk_name
+                )
+
+        # Create snapshot on all disks
+        for disk_name in disk_names:
+            rbd.create_image_snapshot(disk_name, snapshot_name)
+            logger.info(
                 "Snapshot "
                 + snapshot_name
-                + " already exists on image "
+                + " from image "
                 + disk_name
+                + " successfully created"
             )
-        rbd.create_image_snapshot(disk_name, snapshot_name)
-        logger.info(
-            "Snapshot "
-            + snapshot_name
-            + " from image "
-            + disk_name
-            + " successfully created"
-        )
 
 
 def remove_snapshot(vm_name, snapshot_name):
@@ -1026,15 +1181,17 @@ def remove_snapshot(vm_name, snapshot_name):
     :param snapshot_name: the name of the snapshot to be removed
     """
     with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
-        disk_name = OS_DISK_PREFIX + vm_name
-        rbd.remove_image_snapshot(disk_name, snapshot_name)
-        logger.info(
-            "Snapshot "
-            + snapshot_name
-            + " from image "
-            + disk_name
-            + " successfully removed"
-        )
+        disk_names = _get_all_disk_names(rbd, vm_name)
+        for disk_name in disk_names:
+            if rbd.image_snapshot_exists(disk_name, snapshot_name):
+                rbd.remove_image_snapshot(disk_name, snapshot_name)
+                logger.info(
+                    "Snapshot "
+                    + snapshot_name
+                    + " from image "
+                    + disk_name
+                    + " successfully removed"
+                )
 
 
 def list_snapshots(vm_name):
@@ -1065,57 +1222,56 @@ def purge_image(vm_name, date=None, number=None):
         if not isinstance(date, datetime.datetime):
             raise ValueError("Parameter date is not datetime")
 
-        disk_name = OS_DISK_PREFIX + vm_name
         with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
-
-            # snapshot list is sorted by creation date
-            for snap in rbd.list_image_snapshots(disk_name, flat=False):
-                snap_ts = rbd.get_image_snapshot_timestamp(
-                    disk_name, snap["id"]
-                )
-                if snap_ts.timestamp() < date.timestamp():
-                    rbd.remove_image_snapshot(disk_name, snap["name"])
+            for disk_name in _get_all_disk_names(rbd, vm_name):
+                for snap in rbd.list_image_snapshots(disk_name, flat=False):
+                    snap_ts = rbd.get_image_snapshot_timestamp(
+                        disk_name, snap["id"]
+                    )
+                    if snap_ts.timestamp() < date.timestamp():
+                        rbd.remove_image_snapshot(disk_name, snap["name"])
 
             logger.info(
-                "Snapshots of image "
-                + disk_name
+                "Snapshots of VM "
+                + vm_name
                 + " previous to "
                 + str(date)
                 + " have been removed"
             )
 
-    elif number:
-        if not isinstance(number, int) or number < 1:
-            raise ValueError("Parameter number must be a positive integer")
+    elif number is not None:
+        if not isinstance(number, int) or number < 0:
+            raise ValueError("Parameter number must be a non-negative integer")
 
-        disk_name = OS_DISK_PREFIX + vm_name
         with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
+            all_disks = _get_all_disk_names(rbd, vm_name)
+            # To recover from previous errors where not all snapshots were removed
+            min_snap_count = min(
+                len(rbd.list_image_snapshots(d)) for d in all_disks
+            )
+            for disk_name in all_disks:
+                snap_list = rbd.list_image_snapshots(disk_name)
+                to_remove = number + (len(snap_list) - min_snap_count)
+                if len(snap_list) <= to_remove:
+                    rbd.purge_image(disk_name)
+                else:
+                    for snap in snap_list[:to_remove]:
+                        rbd.remove_image_snapshot(disk_name, snap)
 
-            # snapshot list is sorted by creation date
-            snap_list = rbd.list_image_snapshots(disk_name)
-            if len(snap_list) <= number:
-                rbd.purge_image(disk_name)
-                logger.info(
-                    "All snapshots from image "
-                    + disk_name
-                    + " successfully removed"
-                )
-            else:
-                for snap in snap_list[:number]:
-                    rbd.remove_image_snapshot(disk_name, snap)
-                logger.info(
-                    "First "
-                    + str(number)
-                    + " snapshots of image "
-                    + disk_name
-                    + " have been removed"
-                )
+            logger.info(
+                "First "
+                + str(number)
+                + " snapshots of VM "
+                + vm_name
+                + " have been removed"
+            )
     else:
 
         with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
-            disk_name = OS_DISK_PREFIX + vm_name
-            rbd.purge_image(disk_name)
-            logger.info("Image " + disk_name + " successfully purged")
+            disk_names = _get_all_disk_names(rbd, vm_name)
+            for disk_name in disk_names:
+                rbd.purge_image(disk_name)
+            logger.info("VM " + vm_name + " successfully purged")
 
 
 def rollback_snapshot(vm_name, snapshot_name):
@@ -1128,26 +1284,30 @@ def rollback_snapshot(vm_name, snapshot_name):
 
     with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
 
-        disk_name = OS_DISK_PREFIX + vm_name
-        if not rbd.image_snapshot_exists(disk_name, snapshot_name):
-            raise Exception(
-                "Snapshot "
-                + snapshot_name
-                + " does not exist on VM "
-                + vm_name
-            )
+        disk_names = _get_all_disk_names(rbd, vm_name)
+        for dn in disk_names:
+            if not rbd.image_snapshot_exists(dn, snapshot_name):
+                raise Exception(
+                    "Snapshot "
+                    + snapshot_name
+                    + " does not exist on disk "
+                    + dn
+                    + " of VM "
+                    + vm_name
+                )
 
         enabled = is_enabled(vm_name)
         if enabled:
             disable_vm(vm_name)
 
-        rbd.rollback_image(disk_name, snapshot_name)
-        logger.info(
-            "Image "
-            + disk_name
-            + " successfully rollbacked to snapshot "
-            + snapshot_name
-        )
+        for dn in disk_names:
+            rbd.rollback_image(dn, snapshot_name)
+            logger.info(
+                "Image "
+                + dn
+                + " successfully rollbacked to snapshot "
+                + snapshot_name
+            )
 
     if enabled:
         enable_vm(vm_name)

--- a/vm_manager/vm_manager_cmd.py
+++ b/vm_manager/vm_manager_cmd.py
@@ -197,6 +197,20 @@ def get_parser():
             "must be a valid type recognized by libvirt (default virtio)",
         )
 
+        create_parser.add_argument(
+            "--additional-disk",
+            type=str,
+            metavar="PATH",
+            dest="additional_disks",
+            action="append",
+            required=False,
+            default=None,
+            help="Path to an additional qcow2 disk image to import into Ceph "
+            "and attach to the VM. Can be specified multiple times. The "
+            "disks are attached as vdb, vdc, ... and share the --disk-bus "
+            "setting with the system disk.",
+        )
+
         for p in [create_parser, clone_parser, import_parser]:
             p.add_argument(
                 "--disable",


### PR DESCRIPTION
Hello to All, 

As we noticed, the guest.xml.j2 contained partial support for (one) additional disk(s) for VMs. This Pull Request adds this feature also to clusters for an arbitrary amount of disks. However, this contains also a breaking change as the inventory for a VM uses a map instead of a list: 
```
 additional_disk:
     vdb: "../files/data.qcow2" # TODO: Replace with your disk image
```
However, this permits explicitly naming additional disks. 
See also: https://github.com/seapath/ansible/pull/893

Best regards, 
Daniel