### PR TITLE
Refactor duplicate XML/UUID logic into shared module

### DIFF
--- a/tests/test_vm_manager_cluster.py
+++ b/tests/test_vm_manager_cluster.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ElementTree
 import pytest
 
 from vm_manager import vm_manager_cluster as vmc
+from vm_manager.exceptions import UuidConflictError
 from vm_manager.helpers.libvirt import LibVirtManager
 
 TESTDATA_XML_PATH = os.path.join(
@@ -23,6 +24,22 @@ TESTDATA_XML_PATH = os.path.join(
 
 
 def _read_test_xml():
+    """Read the test XML template with UUID stripped.
+
+    Removing the UUID ensures each test VM gets a fresh random UUID
+    and avoids collisions with existing VMs on the cluster.
+    """
+    with open(TESTDATA_XML_PATH) as f:
+        xml = f.read()
+    root = ElementTree.fromstring(xml)
+    uuid_el = root.find("uuid")
+    if uuid_el is not None:
+        root.remove(uuid_el)
+    return ElementTree.tostring(root, encoding="unicode")
+
+
+def _read_test_xml_with_uuid():
+    """Read the test XML template preserving the predefined UUID."""
     with open(TESTDATA_XML_PATH) as f:
         return f.read()
 
@@ -252,19 +269,33 @@ class TestCreateXml:
         result = vmc._create_xml(xml, "myvm")
         assert "<name>myvm</name>" in result
 
-    def test_uuid_preserved_when_provided(self):
-        xml = _read_test_xml()
+    def test_predefined_uuid_preserved(self):
+        xml = _read_test_xml_with_uuid()
         result = vmc._create_xml(xml, "myvm")
-        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" in result
+        root = ElementTree.fromstring(result)
+        assert root.findtext("uuid") == "7b48b1fe-066a-41a6-aef4-f0a9c028f719"
 
-    def test_uuid_generated_when_not_provided(self):
-        xml = _read_test_xml()
-        xml = xml.replace(
-            "<uuid>7b48b1fe-066a-41a6-aef4-f0a9c028f719</uuid>", ""
-        )
+    def test_empty_uuid_generates_new(self):
+        xml = _read_test_xml_with_uuid()
+        xml = xml.replace("7b48b1fe-066a-41a6-aef4-f0a9c028f719", "")
         result = vmc._create_xml(xml, "myvm")
-        assert "<uuid>" in result
-        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" not in result
+        root = ElementTree.fromstring(result)
+        vm_uuid = root.findtext("uuid")
+        assert vm_uuid
+        assert vm_uuid != ""
+
+    def test_missing_uuid_generates_new(self):
+        xml = _read_test_xml()
+        root = ElementTree.fromstring(xml)
+        uuid_el = root.find("uuid")
+        if uuid_el is not None:
+            root.remove(uuid_el)
+        xml_no_uuid = ElementTree.tostring(root).decode()
+        result = vmc._create_xml(xml_no_uuid, "myvm")
+        root = ElementTree.fromstring(result)
+        vm_uuid = root.findtext("uuid")
+        assert vm_uuid
+        assert vm_uuid != ""
 
     def test_rbd_disk_added(self):
         xml = _read_test_xml()
@@ -394,6 +425,51 @@ class TestRemove:
         )
         vmc.remove(vm_name)
         assert vmc.status(vm_name) == "Undefined"
+
+
+# ── list_all_uuids ──────────────────────────────────────────────────
+
+
+class TestListAllUuids:
+    def test_returns_dict(self):
+        result = vmc.list_all_uuids()
+        assert isinstance(result, dict)
+
+    def test_created_vm_uuid_appears(self, created_vm):
+        uuids = vmc.list_all_uuids()
+        assert created_vm in uuids.values()
+
+
+# ── UUID collision ──────────────────────────────────────────────────
+
+
+class TestUuidCollision:
+    def test_duplicate_uuid_raises(self, vm_name, qcow2_image):
+        xml = _read_test_xml_with_uuid()
+        # Create first VM with the predefined UUID
+        vmc.create(
+            {
+                "name": vm_name,
+                "image": qcow2_image,
+                "base_xml": xml,
+                "force": True,
+            }
+        )
+        # Attempt to create second VM with same UUID — should conflict
+        second_name = vm_name + "dup"
+        with pytest.raises(UuidConflictError):
+            vmc.create(
+                {
+                    "name": second_name,
+                    "image": qcow2_image,
+                    "base_xml": xml,
+                }
+            )
+        # Clean up second VM if somehow created
+        try:
+            vmc.remove(second_name)
+        except Exception:
+            pass
 
 
 # ── Snapshots ────────────────────────────────────────────────────────

--- a/tests/test_vm_manager_cluster.py
+++ b/tests/test_vm_manager_cluster.py
@@ -283,19 +283,16 @@ class TestCreateXml:
         vm_uuid = root.findtext("uuid")
         assert vm_uuid
         assert vm_uuid != ""
+        assert vm_uuid != "7b48b1fe-066a-41a6-aef4-f0a9c028f719"
 
     def test_missing_uuid_generates_new(self):
         xml = _read_test_xml()
-        root = ElementTree.fromstring(xml)
-        uuid_el = root.find("uuid")
-        if uuid_el is not None:
-            root.remove(uuid_el)
-        xml_no_uuid = ElementTree.tostring(root).decode()
-        result = vmc._create_xml(xml_no_uuid, "myvm")
+        result = vmc._create_xml(xml, "myvm")
         root = ElementTree.fromstring(result)
         vm_uuid = root.findtext("uuid")
         assert vm_uuid
         assert vm_uuid != ""
+        assert vm_uuid != "7b48b1fe-066a-41a6-aef4-f0a9c028f719"
 
     def test_rbd_disk_added(self):
         xml = _read_test_xml()

--- a/tests/test_vm_manager_libvirt.py
+++ b/tests/test_vm_manager_libvirt.py
@@ -1,9 +1,13 @@
 # Copyright (C) 2025, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
+import xml.etree.ElementTree as ElementTree
+
 import libvirt
+import pytest
 
 from vm_manager import vm_manager_libvirt as vml
+from vm_manager.exceptions import UuidConflictError
 
 
 class TestListVms:
@@ -19,22 +23,37 @@ class TestCreateXml:
         result = vml._create_xml(xml, "myvm")
         assert "<name>myvm</name>" in result
 
-    def test_uuid_preserved_when_provided(self, vm_xml_path):
+    def test_predefined_uuid_preserved(self, vm_xml_path):
         with open(vm_xml_path) as f:
             xml = f.read()
         result = vml._create_xml(xml, "myvm")
-        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" in result
+        root = ElementTree.fromstring(result)
+        assert root.findtext("uuid") == "7b48b1fe-066a-41a6-aef4-f0a9c028f719"
 
-    def test_uuid_generated_when_not_provided(self, vm_xml_path):
+    def test_empty_uuid_generates_new(self, vm_xml_path):
         with open(vm_xml_path) as f:
             xml = f.read()
-        # Remove the uuid element from the XML
-        xml = xml.replace(
-            "<uuid>7b48b1fe-066a-41a6-aef4-f0a9c028f719</uuid>", ""
-        )
+        xml = xml.replace("7b48b1fe-066a-41a6-aef4-f0a9c028f719", "")
         result = vml._create_xml(xml, "myvm")
-        assert "<uuid>" in result
-        assert "7b48b1fe-066a-41a6-aef4-f0a9c028f719" not in result
+        root = ElementTree.fromstring(result)
+        vm_uuid = root.findtext("uuid")
+        assert vm_uuid
+        assert vm_uuid != ""
+
+    def test_missing_uuid_generates_new(self, vm_xml_path):
+        with open(vm_xml_path) as f:
+            xml = f.read()
+        # Remove the entire <uuid> element
+        root = ElementTree.fromstring(xml)
+        uuid_el = root.find("uuid")
+        if uuid_el is not None:
+            root.remove(uuid_el)
+        xml_no_uuid = ElementTree.tostring(root).decode()
+        result = vml._create_xml(xml_no_uuid, "myvm")
+        root = ElementTree.fromstring(result)
+        vm_uuid = root.findtext("uuid")
+        assert vm_uuid
+        assert vm_uuid != ""
 
 
 class TestCreate:
@@ -112,6 +131,39 @@ class TestStatus:
         vml.create({"base_xml": xml, "name": vm_name, "autostart": False})
         vml.start(vm_name)
         assert vml.status(vm_name) == "Started"
+
+
+class TestListAllUuids:
+    def test_returns_dict(self):
+        result = vml.list_all_uuids()
+        assert isinstance(result, dict)
+
+    def test_created_vm_uuid_appears(self, vm_name, vm_xml_path):
+        with open(vm_xml_path) as f:
+            xml = f.read()
+        vml.create({"base_xml": xml, "name": vm_name, "autostart": False})
+        uuids = vml.list_all_uuids()
+        assert vm_name in uuids.values()
+
+
+class TestUuidCollision:
+    def test_duplicate_uuid_raises(self, vm_name, vm_xml_path):
+        with open(vm_xml_path) as f:
+            xml = f.read()
+        # Create first VM with the predefined UUID
+        vml.create({"base_xml": xml, "name": vm_name, "autostart": False})
+        # Attempt to create second VM with same UUID
+        with pytest.raises(UuidConflictError):
+            vml.create(
+                {
+                    "base_xml": xml,
+                    "name": vm_name + "dup",
+                    "autostart": False,
+                }
+            )
+        # Clean up the second VM if it was somehow created
+        if vm_name + "dup" in vml.list_vms():
+            vml.remove(vm_name + "dup")
 
 
 class TestAutostart:

--- a/tests/test_vm_manager_libvirt.py
+++ b/tests/test_vm_manager_libvirt.py
@@ -39,6 +39,7 @@ class TestCreateXml:
         vm_uuid = root.findtext("uuid")
         assert vm_uuid
         assert vm_uuid != ""
+        assert vm_uuid != "7b48b1fe-066a-41a6-aef4-f0a9c028f719"
 
     def test_missing_uuid_generates_new(self, vm_xml_path):
         with open(vm_xml_path) as f:
@@ -54,6 +55,7 @@ class TestCreateXml:
         vm_uuid = root.findtext("uuid")
         assert vm_uuid
         assert vm_uuid != ""
+        assert vm_uuid != "7b48b1fe-066a-41a6-aef4-f0a9c028f719"
 
 
 class TestCreate:

--- a/vm_manager/__init__.py
+++ b/vm_manager/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
+from .exceptions import UuidConflictError  # noqa: F401
+
 try:
     from .helpers.rbd_manager import RbdManager
     from .helpers.pacemaker import Pacemaker
@@ -12,6 +14,7 @@ else:
 if cluster_mode:
     from .vm_manager_cluster import (
         list_vms,
+        list_all_uuids,
         start,
         stop,
         create,
@@ -38,6 +41,7 @@ if cluster_mode:
 else:
     from .vm_manager_libvirt import (
         list_vms,
+        list_all_uuids,
         console,
         create,
         remove,

--- a/vm_manager/exceptions.py
+++ b/vm_manager/exceptions.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2025, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+
+class VmManagerException(Exception):
+    """Base exception for vm_manager errors."""
+
+
+class UuidConflictError(VmManagerException):
+    """Raised when a VM UUID conflicts with an existing VM."""

--- a/vm_manager/helpers/libvirt.py
+++ b/vm_manager/helpers/libvirt.py
@@ -52,6 +52,12 @@ class LibVirtManager:
         """
         return [x.name() for x in self._conn.listAllDomains()]
 
+    def list_uuids(self):
+        """
+        Return dict mapping UUID strings to domain names.
+        """
+        return {d.UUIDString(): d.name() for d in self._conn.listAllDomains()}
+
     def get_virsh_secrets(self):
         """
         Get the virsh secrets

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -18,6 +18,7 @@ import json
 from .helpers.rbd_manager import RbdManager
 from .helpers.pacemaker import Pacemaker
 from .helpers.libvirt import LibVirtManager
+from .exceptions import UuidConflictError
 
 XML_PACEMAKER_PATH = "/etc/pacemaker"
 
@@ -33,6 +34,29 @@ logger = logging.getLogger(__name__)
 """
 A module to manage VMs in Seapath cluster.
 """
+
+
+def list_all_uuids():
+    """
+    Return dict mapping UUID strings to VM names by reading XML
+    metadata from each VM's system disk in the RBD cluster.
+    """
+    uuids = {}
+    with RbdManager(CEPH_CONF, POOL_NAME, NAMESPACE) as rbd:
+        for vm_name in rbd.list_groups():
+            disk_name = OS_DISK_PREFIX + vm_name
+            try:
+                xml_str = rbd.get_image_metadata(disk_name, "xml")
+                xml_root = ElementTree.fromstring(xml_str)
+                vm_uuid = xml_root.findtext("uuid")
+                if vm_uuid:
+                    uuids[vm_uuid] = vm_name
+            except Exception:
+                logger.warning(
+                    "Could not read UUID for VM %s, skipping",
+                    vm_name,
+                )
+    return uuids
 
 
 def _check_name(name):
@@ -347,6 +371,23 @@ def create(vm_options_with_nones):
         progress = vm_options["progress"]
     except KeyError:
         progress = False
+
+    # Check for UUID collision before importing the disk
+    xml = _create_xml(
+        vm_options["base_xml"],
+        vm_options["name"],
+        vm_options.get("disk_bus", "virtio"),
+    )
+    xml_root = ElementTree.fromstring(xml)
+    vm_uuid = xml_root.findtext("uuid")
+    if vm_uuid:
+        existing = list_all_uuids()
+        if vm_uuid in existing:
+            raise UuidConflictError(
+                "UUID {} is already used by VM {}".format(
+                    vm_uuid, existing[vm_uuid]
+                )
+            )
 
     # Create VM group
     if "force" not in vm_options:

--- a/vm_manager/vm_manager_cluster.py
+++ b/vm_manager/vm_manager_cluster.py
@@ -6,7 +6,6 @@
 import os
 import sys
 import logging
-import uuid
 import re
 import datetime
 from errno import ENOENT
@@ -18,7 +17,7 @@ import json
 from .helpers.rbd_manager import RbdManager
 from .helpers.pacemaker import Pacemaker
 from .helpers.libvirt import LibVirtManager
-from .exceptions import UuidConflictError
+from .xml_utils import prepare_xml_base, check_uuid_conflict
 
 XML_PACEMAKER_PATH = "/etc/pacemaker"
 
@@ -134,21 +133,7 @@ def _create_xml(xml, vm_name, target_disk_bus="virtio"):
             Default: virtio
     """
     disk_name = OS_DISK_PREFIX + vm_name
-    xml_root = ElementTree.fromstring(xml)
-    try:
-        xml_root.remove(xml_root.findall("./name")[0])
-    except IndexError:
-        pass
-    existing_uuid = xml_root.findall("./uuid")
-    if not existing_uuid or not existing_uuid[0].text:
-        try:
-            xml_root.remove(existing_uuid[0])
-        except IndexError:
-            pass
-        uuid_element = ElementTree.SubElement(xml_root, "uuid")
-        uuid_element.text = str(uuid.uuid4())
-    name_element = ElementTree.SubElement(xml_root, "name")
-    name_element.text = vm_name
+    xml_root = prepare_xml_base(xml, vm_name)
     rbd_secret = None
     hosts_list = _get_ceph_hosts_xml()
     with LibVirtManager() as libvirt_manager:
@@ -378,16 +363,7 @@ def create(vm_options_with_nones):
         vm_options["name"],
         vm_options.get("disk_bus", "virtio"),
     )
-    xml_root = ElementTree.fromstring(xml)
-    vm_uuid = xml_root.findtext("uuid")
-    if vm_uuid:
-        existing = list_all_uuids()
-        if vm_uuid in existing:
-            raise UuidConflictError(
-                "UUID {} is already used by VM {}".format(
-                    vm_uuid, existing[vm_uuid]
-                )
-            )
+    check_uuid_conflict(xml, list_all_uuids)
 
     # Create VM group
     if "force" not in vm_options:

--- a/vm_manager/vm_manager_libvirt.py
+++ b/vm_manager/vm_manager_libvirt.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .helpers.libvirt import LibVirtManager
-from .exceptions import UuidConflictError
+from .xml_utils import prepare_xml_base, check_uuid_conflict
 import xml.etree.ElementTree as ElementTree
-import uuid
 import logging
 
 logger = logging.getLogger(__name__)
@@ -36,22 +35,7 @@ def _create_xml(xml, vm_name):
     Creates a libvirt configuration file according to xml and
     vm_name parameters.
     """
-    xml_root = ElementTree.fromstring(xml)
-    try:
-        xml_root.remove(xml_root.findall("./name")[0])
-    except IndexError:
-        pass
-    existing_uuid = xml_root.findall("./uuid")
-    if not existing_uuid or not existing_uuid[0].text:
-        try:
-            xml_root.remove(existing_uuid[0])
-        except IndexError:
-            pass
-        uuid_element = ElementTree.SubElement(xml_root, "uuid")
-        uuid_element.text = str(uuid.uuid4())
-    name_element = ElementTree.SubElement(xml_root, "name")
-    name_element.text = vm_name
-
+    xml_root = prepare_xml_base(xml, vm_name)
     return ElementTree.tostring(xml_root).decode()
 
 
@@ -63,17 +47,7 @@ def create(args):
     :param base_xml:  the VM libvirt xml configuration
     """
     xml = _create_xml(args.get("base_xml"), args.get("name"))
-
-    xml_root = ElementTree.fromstring(xml)
-    vm_uuid = xml_root.findtext("uuid")
-    if vm_uuid:
-        existing = list_all_uuids()
-        if vm_uuid in existing:
-            raise UuidConflictError(
-                "UUID {} is already used by VM {}".format(
-                    vm_uuid, existing[vm_uuid]
-                )
-            )
+    check_uuid_conflict(xml, list_all_uuids)
 
     with LibVirtManager() as lvm:
         lvm.define(xml)

--- a/vm_manager/vm_manager_libvirt.py
+++ b/vm_manager/vm_manager_libvirt.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .helpers.libvirt import LibVirtManager
+from .exceptions import UuidConflictError
 import xml.etree.ElementTree as ElementTree
 import uuid
 import logging
@@ -20,6 +21,14 @@ def list_vms():
     """
     with LibVirtManager() as lvm:
         return lvm.list()
+
+
+def list_all_uuids():
+    """
+    Return dict mapping UUID strings to VM names for all local VMs.
+    """
+    with LibVirtManager() as lvm:
+        return lvm.list_uuids()
 
 
 def _create_xml(xml, vm_name):
@@ -54,6 +63,17 @@ def create(args):
     :param base_xml:  the VM libvirt xml configuration
     """
     xml = _create_xml(args.get("base_xml"), args.get("name"))
+
+    xml_root = ElementTree.fromstring(xml)
+    vm_uuid = xml_root.findtext("uuid")
+    if vm_uuid:
+        existing = list_all_uuids()
+        if vm_uuid in existing:
+            raise UuidConflictError(
+                "UUID {} is already used by VM {}".format(
+                    vm_uuid, existing[vm_uuid]
+                )
+            )
 
     with LibVirtManager() as lvm:
         lvm.define(xml)

--- a/vm_manager/xml_utils.py
+++ b/vm_manager/xml_utils.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2026 Savoir-faire Linux Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import uuid
+import xml.etree.ElementTree as ElementTree
+
+from .exceptions import UuidConflictError
+
+
+def prepare_xml_base(xml, vm_name):
+    """
+    Prepare a libvirt XML configuration by setting the VM name and
+    generating a UUID if none is provided.
+
+    :param xml: the base libvirt XML string
+    :param vm_name: the VM name to set
+    :return: the modified ElementTree root element
+    """
+    xml_root = ElementTree.fromstring(xml)
+    try:
+        xml_root.remove(xml_root.findall("./name")[0])
+    except IndexError:
+        pass
+    existing_uuid = xml_root.findall("./uuid")
+    if not existing_uuid or not existing_uuid[0].text:
+        try:
+            xml_root.remove(existing_uuid[0])
+        except IndexError:
+            pass
+        uuid_element = ElementTree.SubElement(xml_root, "uuid")
+        uuid_element.text = str(uuid.uuid4())
+    name_element = ElementTree.SubElement(xml_root, "name")
+    name_element.text = vm_name
+    return xml_root
+
+
+def check_uuid_conflict(xml, list_all_uuids_fn):
+    """
+    Check that the UUID in a libvirt XML does not conflict with
+    existing VMs.
+
+    :param xml: the libvirt XML string to check
+    :param list_all_uuids_fn: callable returning a dict of
+        {uuid_str: vm_name}
+    :raises UuidConflictError: if the UUID is already in use
+    """
+    xml_root = ElementTree.fromstring(xml)
+    vm_uuid = xml_root.findtext("uuid")
+    if vm_uuid:
+        existing = list_all_uuids_fn()
+        if vm_uuid in existing:
+            raise UuidConflictError(
+                "UUID {} is already used by VM {}".format(
+                    vm_uuid, existing[vm_uuid]
+                )
+            )


### PR DESCRIPTION
- Add UUID collision detection for predefined VM UUIDs
- Add explicit errors when a UUID conflict is detected
- Add UUID cluster tests
- Extract duplicated XML name/UUID handling and UUID conflict checking from `vm_manager_cluster.py` and `vm_manager_libvirt.py` into a new `vm_manager/xml_utils.py` module
- Both modules now call shared `prepare_xml_base()` and `check_uuid_conflict()` functions, reducing code duplication by ~50 lines