### PR TITLE
xml_utils: insert <name> at position 0, not at the end

### DIFF
--- a/vm_manager/xml_utils.py
+++ b/vm_manager/xml_utils.py
@@ -29,8 +29,9 @@ def prepare_xml_base(xml, vm_name):
             pass
         uuid_element = ElementTree.SubElement(xml_root, "uuid")
         uuid_element.text = str(uuid.uuid4())
-    name_element = ElementTree.SubElement(xml_root, "name")
+    name_element = ElementTree.Element("name")
     name_element.text = vm_name
+    xml_root.insert(0, name_element)
     return xml_root
 
 


### PR DESCRIPTION
SubElement always appends to the end of the parent element. When the input XML already contains children (os, memory, devices, etc.), the <name> element ended up after all of them, violating libvirt's strict RNG schema ordering and triggering "Extra element os in interleave".

Use Element + insert(0, ...) to place <name> first, as required.