### PR TITLE
vm_manager: fix --no-autostart option

### DIFF
--- a/vm_manager/vm_manager_cmd.py
+++ b/vm_manager/vm_manager_cmd.py
@@ -530,10 +530,7 @@ def main():
     if args.command == "list":
         print("\n".join(vm_manager.list_vms()))
     elif args.command == "start":
-        if vm_manager.cluster_mode:
-            vm_manager.start(args.name)
-        else:
-            vm_manager.start(args.name, autostart=not args.no_autostart)
+        vm_manager.start(args.name)
     elif args.command == "stop":
         vm_manager.stop(args.name, force=args.force)
     elif args.command == "remove":

--- a/vm_manager/vm_manager_libvirt.py
+++ b/vm_manager/vm_manager_libvirt.py
@@ -51,7 +51,7 @@ def create(args):
 
     with LibVirtManager() as lvm:
         lvm.define(xml)
-        if args.get("autostart"):
+        if not args.get("no_autostart"):
             lvm.set_autostart(args.get("name"), True)
 
     logger.info("VM " + args.get("name") + " created successfully")


### PR DESCRIPTION
Commit [1] added the --no-autostart option to the create command. However, the option was given to the start command, and ignored by the create command. This makes vm-manager to fail when using the start command.
This commit fixes this.

[1]: https://github.com/seapath/vm_manager/commit/f60c3e882fa758259221720a8b60545c885f151a