### PR TITLE
Fix the red SonarCloud gate on main

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -11,21 +11,10 @@ RUN set -x \
         python3-setuptools \
         python3-sphinx \
         python3-pip \
-        openjdk-8-jre-headless \
-        unzip \
-        wget \
     && rm -rf /var/lib/apt/lists/ \
-    && pip3 install --no-cache-dir sphinx-argparse
-
-ARG sonar_version=4.7.0.2747
-ARG sonar_repo=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli
-RUN set -x \
-    && wget -O /tmp/sonar-scanner.zip \
-    "${sonar_repo}/sonar-scanner-cli-${sonar_version}.zip" \
-    && cd /opt \
-    && unzip /tmp/sonar-scanner.zip \
-    && rm -f sonar-scanner.zip
-RUN ln -s "/opt/sonar-scanner-${sonar_version}" /opt/sonar-scanner
-RUN echo 'sonar.host.url=http://j1.sfl.team:9000/' \
-    > /opt/sonar-scanner/conf/sonar-scanner.properties
-COPY python-sonar.sh /usr/bin/python-sonar.sh
+    # Pinned so a rebuild does not pick up a new release on its own, and
+    # restricted to wheels so no dependency gets to run a setup script
+    # during the install. 0.6.0 is what the unpinned line already
+    # resolved to on the python3.10 of ubuntu 22.04.
+    && pip3 install --no-cache-dir --only-binary :all: \
+        sphinx-argparse==0.6.0

--- a/.cqfd/docker/python-sonar.sh
+++ b/.cqfd/docker/python-sonar.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-pylint --exit-zero "$@" >pylint-report.txt
-/opt/sonar-scanner/bin/sonar-scanner -Dsonar.analysis.mode=preview -Dsonar.report.export.path=sonar-report.json

--- a/.cqfdrc
+++ b/.cqfdrc
@@ -2,16 +2,10 @@
 org='rte'
 name='vm_manager'
 
-flavors='check sonar check_format format flake docs'
+flavors='check check_format format flake docs'
 
 [build]
 command='/usr/bin/pip install --root-user-action=ignore --prefix=. .'
-
-[sonar]
-command='/usr/bin/python-sonar.sh \
-        pacemaker_helper \
-        rbd_helper \
-        vm_manager'
 
 [check]
 command='pylint \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,25 @@ jobs:
             htmlcov/
           if-no-files-found: ignore
 
+      - name: Read the project version
+        id: version
+        # The SonarCloud project compares against the previous version to
+        # decide what counts as new code. Every analysis so far ran without
+        # a version, so there was no boundary and the period fell back to
+        # the first analysis ever: the whole code base counted as new, and
+        # publishing coverage turned the main branch gate red on 2000 lines
+        # of pre-existing code. Feeding the scanner the version from
+        # pyproject.toml, the single source of truth, gives the period a
+        # real boundary at each release.
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import pathlib
+          import tomllib
+
+          pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          print("version=" + pyproject["project"]["version"])
+          PY
+
       # Automatic Analysis must stay off in the SonarCloud project
       # settings, otherwise SonarCloud rejects this analysis. Skipped when
       # SONAR_TOKEN is unavailable, which is the case for pull requests
@@ -108,6 +127,8 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          args: -Dsonar.projectVersion=${{ steps.version.outputs.version }}
 
       - name: Install documentation dependencies
         # Editable too, so this step adds the docs extra instead of

--- a/tests/test_vm_manager_api.py
+++ b/tests/test_vm_manager_api.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the Flask REST API.
+
+Every vm_manager entry point the routes call is replaced here, so nothing
+touches libvirt, Ceph or Pacemaker.
+
+In production this module is not run directly: the vmmgrapi role of
+seapath/ansible serves `app` with gunicorn on a unix socket, behind an
+nginx that carries the TLS, the authentication and the ACL. main() is a
+debug entry point, and since the application authenticates nobody on its
+own, the address it binds to is worth pinning down in a test.
+"""
+
+import pytest
+
+from vm_manager import vm_manager_api
+
+
+@pytest.fixture
+def client():
+    """Return a test client for the API."""
+    return vm_manager_api.app.test_client()
+
+
+def test_main_binds_the_loopback(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        vm_manager_api.app, "run", lambda **kwargs: calls.append(kwargs)
+    )
+
+    vm_manager_api.main()
+
+    assert calls == [{"host": "127.0.0.1"}]
+
+
+def test_list_vms(client, monkeypatch):
+    monkeypatch.setattr(vm_manager_api.v, "list_vms", lambda: ["vm1", "vm2"])
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.get_json() == ["vm1", "vm2"]
+
+
+def test_status(client, monkeypatch):
+    monkeypatch.setattr(
+        vm_manager_api.v, "status", lambda guest: f"{guest} is Running"
+    )
+
+    response = client.get("/status/guest0")
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "guest0 is Running"
+
+
+def test_stop(client, monkeypatch):
+    monkeypatch.setattr(
+        vm_manager_api.v, "stop", lambda guest: f"{guest} stopped"
+    )
+
+    response = client.get("/stop/guest0")
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "guest0 stopped"
+
+
+def test_start_reports_a_silent_success(client, monkeypatch):
+    """A backend returning nothing is a success, not an empty answer."""
+    monkeypatch.setattr(vm_manager_api.v, "start", lambda guest: None)
+
+    response = client.get("/start/guest0")
+
+    assert response.status_code == 200
+    assert "should be OK" in response.get_data(as_text=True)
+
+
+def test_start_reports_the_backend_error(client, monkeypatch):
+    def raise_error(guest):
+        raise RuntimeError(f"no such VM: {guest}")
+
+    monkeypatch.setattr(vm_manager_api.v, "start", raise_error)
+
+    response = client.get("/start/guest0")
+
+    assert response.status_code == 500
+    assert (
+        response.get_data(as_text=True) == "RuntimeError: no such VM: guest0"
+    )

--- a/vm_manager/vm_manager_api.py
+++ b/vm_manager/vm_manager_api.py
@@ -44,7 +44,13 @@ def start_vm(guest):
 
 
 def main():
-    app.run(host="0.0.0.0")
+    # Loopback on purpose. In production this module is imported by the
+    # wsgi.py of the vmmgrapi Ansible role and served by gunicorn on a
+    # unix socket, behind an nginx that carries the TLS, the basic auth
+    # and the ACL. This entry point is for local debugging only, and
+    # listening on every interface would publish every route, in clear
+    # text and unauthenticated, around all of that.
+    app.run(host="127.0.0.1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Publishing coverage in #94 turned the `main` gate red. Nothing regressed: `new_coverage` was simply an ignored condition as long as no report existed.

The project's New Code definition is "previous version", and every analysis in the history ran without one. With no version event to compare against, the period falls back to the first analysis ever, dated 2024-07-31: `new_lines` 3562 for `ncloc` 3334, so the entire code base counts as new code. Hence `new_coverage` 21.1 against a threshold of 80, and `new_security_rating` C from findings dating back to 2021. Pull requests were never affected, their gate is computed on their own diff.

The first commit is the fix, the others clear the security findings that are worth clearing:

- `ci:` pass the version from `pyproject.toml` to the scanner, so each release gives the period a real boundary.
- `api:` the Flask debug entry point listened on `0.0.0.0` while the application authenticates nobody, publishing `/start` and `/stop` in clear text around the nginx that carries the TLS, the basic auth and the ACL. It is not the production path, gunicorn imports `wsgi:app`. Fixes `python:S8392`, the only blocker.
- `cqfd:` pin `sphinx-argparse` and install it from wheels only, as the workflow steps already are. Fixes `docker:S8544` and `docker:S8541`.
- `cqfd:` drop the sonar-scanner 4.7.0 aimed at `http://j1.sfl.team:9000/`, which this repository no longer reports to since the analysis moved to the workflow. Takes openjdk-8, unzip and wget out of the image, and fixes `docker:S6506` and `docker:S5332`.
- `tests:` cover the REST API, 0% to 94%. Without it the single line changed above, in a module at 0%, failed this pull request's own gate: 1 new line to cover, 0 covered.

Six of the ten security findings clear. The remaining four, `pythonsecurity:S8701` and `S8707` on paths built from argparse arguments, need real input validation rather than a one-line fix and are left out.